### PR TITLE
Fixups to the cromwell notebooks

### DIFF
--- a/cromwell_setup/cromwell_examples.ipynb
+++ b/cromwell_setup/cromwell_examples.ipynb
@@ -24,6 +24,7 @@
    "cell_type": "markdown",
    "id": "61d34c2a",
    "metadata": {
+    "jp-MarkdownHeadingCollapsed": true,
     "tags": []
    },
    "source": [
@@ -41,12 +42,44 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1af2b88e-cda8-4e94-935c-02f7a51f3430",
+   "metadata": {},
+   "source": [
+    "### Notebook setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "06544a3c-37ed-43cd-8b9f-34909da0e2f2",
+   "metadata": {},
+   "source": [
+    "#### Set up utility functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "51ed589c-2918-4b13-b10d-5d7b90f44289",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "'''\n",
+    "Resolves bucket URL from bucket reference in workspace.\n",
+    "'''\n",
+    "def get_bucket_url_from_reference(bucket_reference):\n",
+    "    BUCKET_CMD_OUTPUT = !terra resolve --name={bucket_reference}\n",
+    "    BUCKET = BUCKET_CMD_OUTPUT[0]\n",
+    "    return BUCKET"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "50dd37b1",
    "metadata": {
     "tags": []
    },
    "source": [
-    "### Notebook setup <a id=\"workspace_setup\"> \n",
+    "#### Workspace setup\n",
     "<div class=\"alert alert-block alert-info\">\n",
     "<b>Note:</b> This notebook assumes that `workspace_setup.ipynb` in the parent directory has been run.\n",
     "</div>\n",
@@ -74,27 +107,55 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60e9a27f-fcf8-4b5a-81d2-83d2ecd6934d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MY_BUCKET = get_bucket_url_from_reference(BUCKET_REFERENCE)\n",
+    "print(f'Bucket ID: {MY_BUCKET}')"
+   ]
+  },
+  {
    "cell_type": "markdown",
-   "id": "95db518b",
+   "id": "b01c7eec-e88d-4731-b04b-23e246c6f368",
    "metadata": {
     "tags": []
    },
    "source": [
-    "#### Set notebook globals"
+    "#### Cloud environment setup\n",
+    "\n",
+    "The notebooks in this workspace create a few files on your cloud environment. For clarity and to ease cleanup after\n",
+    "running the tutorials, the notebooks will write, by default to a well-defined location as determined by the\n",
+    "`CROMWELL_EXAMPLES_DIR`. You are free to change this location to suit your own use cases."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "245d004b",
+   "id": "f978a1d7-c8f5-4390-b846-839cc7571129",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
     "\n",
-    "# Get Terra user email from environment.\n",
-    "MY_USER_EMAIL = os.environ['TERRA_USER_EMAIL']\n",
-    "print(f'Terra User Email: {MY_USER_EMAIL}')"
+    "CROMWELL_EXAMPLES_DIR=os.path.expanduser('~/terra-tutorials/cromwell')\n",
+    "CROMWELL_CONF=f'{CROMWELL_EXAMPLES_DIR}/cromwell.runmode.conf'\n",
+    "\n",
+    "HELLO_WORLD_INPUTS_JSON=f'{CROMWELL_EXAMPLES_DIR}/hello_world.inputs.json'\n",
+    "SAMPLE_INPUTS_JSON=f'{CROMWELL_EXAMPLES_DIR}/sample.inputs.json'\n",
+    "\n",
+    "RUNMODE_LOG=f'{CROMWELL_EXAMPLES_DIR}/cromwell.run.log'\n",
+    "\n",
+    "!mkdir -p {CROMWELL_EXAMPLES_DIR}\n",
+    "\n",
+    "print(f'Tutorial files will be written locally to {CROMWELL_EXAMPLES_DIR}')\n",
+    "print()\n",
+    "print(f'Cromwell configuration file will be written to {CROMWELL_CONF}')\n",
+    "print(f'Cromwell hello-world input JSON file will be written to {HELLO_WORLD_INPUTS_JSON}')\n",
+    "print(f'Cromwell runmode log file will be written to {RUNMODE_LOG}')\n",
+    "print(f'Cromwell samples input JSON file will be written to {SAMPLE_INPUTS_JSON}')"
    ]
   },
   {
@@ -113,7 +174,8 @@
    "metadata": {},
    "source": [
     "### Do I need to install `Cromwell` or other dependencies in my Terra workspace?\n",
-    "By default, Cromwell is installed as a Java jar in Terra workspaces, so you don't need to install anything to complete the exercises in this notebook."
+    "\n",
+    "The Cromwell (Java) JAR file is installed on Terra cloud environments by default, so you don't need to install anything to complete the exercises in this notebook."
    ]
   },
   {
@@ -152,7 +214,9 @@
    "id": "671fa388",
    "metadata": {},
    "source": [
-    "Run the cell below to output the contents of `~/terra-solutions-mc-terra-testing/1000_genomes/workflows/wdl/helloWorld.wdl`, the WDL file for the first workflow we will run. Note that the workflow expects a value for the input parameter `name`."
+    "Run the cell below to output the contents of `helloWorld.wdl`, the WDL file for the first workflow we will run.\n",
+    "\n",
+    "This workflow has no file input, but instead just accepts a string input parameter `name`."
    ]
   },
   {
@@ -172,6 +236,10 @@
    "source": [
     "#### Provide inputs\n",
     "\n",
+    "WDL supports the specification of complex inputs, including (but not limited to)\n",
+    "`String`s, `Integer`s, `File`s, and `Array`s. These complex inputs are provided in\n",
+    "a JSON file, frequently refered to as the `inputs.json`.\n",
+    "\n",
     "Run the cell below to create an input file `hello_world_inputs.json` which sets\n",
     "the input `name` to your Terra user email."
    ]
@@ -183,11 +251,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
     "import json\n",
     "\n",
-    "data = {\"test_workflow.name\" : f\"{MY_USER_EMAIL}\"}\n",
-    "with open ('hello_world_inputs.json', 'w') as json_file:\n",
-    "    json.dump(data, json_file)"
+    "# Get Terra user email from environment.\n",
+    "MY_USER_EMAIL = os.environ['TERRA_USER_EMAIL']\n",
+    "\n",
+    "# Create an input file with the \n",
+    "data = {\"hello_world.name\" : f\"{MY_USER_EMAIL}\"}\n",
+    "with open (HELLO_WORLD_INPUTS_JSON, 'w') as json_file:\n",
+    "    json.dump(data, json_file, indent=2)"
    ]
   },
   {
@@ -205,7 +278,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!cat hello_world_inputs.json"
+    "!cat {HELLO_WORLD_INPUTS_JSON}"
    ]
   },
   {
@@ -227,11 +300,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!java -jar $CROMWELL_JAR \\\n",
+    "%%bash -s {HELLO_WORLD_INPUTS_JSON} {RUNMODE_LOG}\n",
+    "\n",
+    "HELLO_WORLD_INPUTS_JSON=\"$1\"\n",
+    "RUNMODE_LOG=\"$2\"\n",
+    "\n",
+    "java -jar $CROMWELL_JAR \\\n",
     "  run \\\n",
     "  workflows/wdl/helloWorld.wdl \\\n",
-    "  --inputs hello_world_inputs.json \\\n",
-    "  &> cromwell.run.log"
+    "  --inputs \"${HELLO_WORLD_INPUTS_JSON}\" \\\n",
+    "  &> \"${RUNMODE_LOG}\"\n"
    ]
   },
   {
@@ -267,7 +345,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!tail --lines=50 cromwell.run.log"
+    "!tail --lines=50 {RUNMODE_LOG}"
    ]
   },
   {
@@ -283,29 +361,8 @@
     "\n",
     "<div class=\"alert alert-block alert-info\">\n",
     "<b>Note:</b>\n",
-    "You'll need to launch a Cromwell server before submitting any jobs in server mode by running the <a href=\"terra-solutions-mc-terra-testing/1000_genomes/launch_cromwell_server.ipynb\">launch_cromwell_server.ipynb</a> notebook in this directory.\n",
+    "You'll need to launch a Cromwell server before submitting any jobs in server mode by running the cromwell_server_management.ipynb</a> notebook in this directory.\n",
     "</div>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f46bd24e-177f-49ce-bc76-23a808404191",
-   "metadata": {},
-   "source": [
-    "#### Configure output directory\n",
-    "\n",
-    "Run the cell below to direct workflow outputs to the specified directory. You can change the location of the workflow output by replacing the value of `final_workflow_outputs_dir` and running the cell below."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "02ed9507-72b5-46c0-82dd-6a79067dc76b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%writefile ~/options.json\n",
-    "{\"final_workflow_outputs_dir\" : \"/home/jupyter/terra-axon-examples/cromwell_setup/cromwell-workflow-logs/cromwell/output/\"}"
    ]
   },
   {
@@ -363,12 +420,13 @@
    },
    "outputs": [],
    "source": [
-    "%%bash\n",
+    "%%bash -s {HELLO_WORLD_INPUTS_JSON}\n",
+    "\n",
+    "HELLO_WORLD_INPUTS_JSON=\"$1\"\n",
     "\n",
     "cromshell submit \\\n",
-    "  ~/terra-axon-examples/cromwell_setup/workflows/wdl/helloWorld.wdl \\\n",
-    "  hello_world_inputs.json \\\n",
-    "  ~/options.json"
+    "  workflows/wdl/helloWorld.wdl \\\n",
+    "  \"${HELLO_WORLD_INPUTS_JSON}\""
    ]
   },
   {
@@ -487,7 +545,7 @@
     "for d in data:\n",
     "    print(f\"{d}: {data[d]}\")\n",
     "\n",
-    "with open ('sample_inputs.json', 'w') as json_file:\n",
+    "with open (SAMPLE_INPUTS_JSON, 'w') as json_file:\n",
     "    json.dump(data, json_file)"
    ]
   },
@@ -498,7 +556,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!cromshell submit ~/terra-axon-examples/cromwell_setup/workflows/wdl/cramToBam.wdl ~/terra-axon-examples/cromwell_setup/sample_inputs.json ~/options.json"
+    "!cromshell submit workflows/wdl/cramToBam.wdl {SAMPLE_INPUTS_JSON}"
    ]
   },
   {

--- a/cromwell_setup/workflows/wdl/helloWorld.wdl
+++ b/cromwell_setup/workflows/wdl/helloWorld.wdl
@@ -1,21 +1,38 @@
+# helloWorld.wdl - A single-stage demonstration workflow in WDL
+
 version 1.0
 
+# Task hello
+#
+# Parameters:
+# - name (String): something to say hello to
+#
+# Results:
+# - Emits "hello <name>" to standard output.
 task hello {
     input {
-      String name = "World"
+      String name
     }
     
     command {
         echo "Hello ${name}!"
     }
+
+    runtime {
+        docker: "debian:stable-slim"
+    }
+    
     output {
         File response = stdout()
     }
 }
 
-workflow test_workflow {
+# Workflow hello_world
+#
+# Accepts as input an optional "name" parameter and calls the "hello" task.
+workflow hello_world {
   input {
-    String name
+    String name = "World"
   }
   
   call hello {


### PR DESCRIPTION
This pull request fixes the cromwell_examples notebook so that they work with cromwell in server mode. 
  - Specify an image in helloWorld.wdl
  - Remove the options.json file that attempts to write the outputs back to disk.

In addition, it also writes generated files (such as input.json and log files) to a directory outside the git repo, named `~/terra-tutorials`