### PR TITLE
migrate the hail on dataproc examples...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.bak*
+.DS_Store
+.ipynb_checkpoints

--- a/dataproc/README.md
+++ b/dataproc/README.md
@@ -1,0 +1,7 @@
+# Dataproc + Hail on Enterprise Terra
+
+This example shows how to get started with Dataproc + Hail on Enterprise Terra.
+
+- The [create_hail_cluster.ipynb](./create_hail_cluster.ipynb) notebook shows how to start up a Dataproc cluster with Hail installed, how to submit batch jobs to the cluster, and how to run an interactive analysis via a JupyterLab server on a cluster node.
+- The [annotate_significant_gwas_results_with_gnomad.ipynb](./annotate_significant_gwas_results_with_gnomad.ipynb) notebook shows a Hail example.
+- The `hail_demo_dashboard.md` file is used for the *Description* field of an Enterprise Terra workspace that demos this example.

--- a/dataproc/annotate_significant_gwas_results_with_gnomad.ipynb
+++ b/dataproc/annotate_significant_gwas_results_with_gnomad.ipynb
@@ -1,0 +1,662 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Annotate significant GWAS results with gnomAD"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this notebook, we use [Hail](https://hail.is/) to annotate the significant GWAS results with [gnomAD](https://gnomad.broadinstitute.org/).\n",
+    "\n",
+    "GWAS results from *\"Whole genome sequence analysis of blood lipid levels in >66,000 individuals. [Selvaraj et al 2021](https://www.biorxiv.org/content/10.1101/2021.10.11.463514v1.supplementary-material)\"* are used. There are only 338 significant LDL results to annotate, so it might be faster to annotate using a tool other than Hail, but this notebook is meant to be illustrative.\n",
+    "\n",
+    "The gnomAD table is enormous and this notebook makes use of [filter_intervals](https://hail.is/docs/0.2/methods/genetics.html#hail.methods.filter_intervals) to remove irrelevant gnomAD data partitions from the analysis.\n",
+    "* If you want this notebook to run quickly (~5 min), be sure to set `INTERVALS_TO_EXAMINE` to a small region of the genome such as APOE.\n",
+    "* If you want this notebook to run for a while (~30 minutes), set `INTERVALS_TO_EXAMINE` to include all autosomes.\n",
+    "\n",
+    "If you want to run this notebook in batch mode as a script, in the terminal run `jupyter nbconvert --to script annotate_significant_gwas_results_with_gnomad.ipynb`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Setup "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "import hail as hl\n",
+    "import os\n",
+    "import pandas as pd\n",
+    "from plotnine import *\n",
+    "import subprocess\n",
+    "import time"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define constants"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Papermill parameters. See https://papermill.readthedocs.io/en/latest/usage-parameterize.html\n",
+    "\n",
+    "#---[ Inputs ]---\n",
+    "# The gnomAD v3.1.2 data set contains 76,156 whole genomes (and no exomes), all mapped to the GRCh38 reference sequence.\n",
+    "# See also https://gnomad.broadinstitute.org/downloads\n",
+    "GNOMAD_TAB = 'gs://gcp-public-data--gnomad/release/3.1.2/ht/genomes/gnomad.genomes.v3.1.2.sites.ht'\n",
+    "# GRCh38 GWAS results from https://www.biorxiv.org/content/10.1101/2021.10.11.463514v1.supplementary-material\n",
+    "SELVARAJ_LIPIDS_GWAS_RESULTS = 'https://www.biorxiv.org/content/biorxiv/early/2021/10/12/2021.10.11.463514/DC1/embed/media-1.xlsx?download=true'\n",
+    "\n",
+    "# To run at scale, use these intervals for all autosomes.\n",
+    "#INTERVALS_TO_EXAMINE = ['chr1-chr22'] \n",
+    "# To perform a quick test, use these intervals for APOE\n",
+    "# https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&lastVirtModeType=default&lastVirtModeExtraState=&virtModeType=default&virtMode=0&nonVirtPosition=&position=chr19%3A44905796%2D44909393&hgsid=1411550209_Ip7W0XTmGpvEfKONETLScNT3MOVv\n",
+    "INTERVALS_TO_EXAMINE = ['chr19:44905796-44909393']\n",
+    "\n",
+    "#---[ Outputs ]---\n",
+    "OUTPUT_BUCKET = os.getenv('WORKSPACE_BUCKET')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "#---[ Form output path from parameter values ]---\n",
+    "if not OUTPUT_BUCKET:\n",
+    "    # This notebook is not running in app.terra.bio or the All of Us Researcher Workbench.\n",
+    "    raise ValueError('Specify the value for parameter OUTPUT_BUCKET.')\n",
+    "\n",
+    "INTERVALS_TO_EXAMINE_NAME = '_'.join(INTERVALS_TO_EXAMINE).replace(':', 'range')\n",
+    "\n",
+    "# Create a timestamp for a folder of results generated today.\n",
+    "DATESTAMP = time.strftime('%Y%m%d')\n",
+    "TIMESTAMP = time.strftime('%Y%m%d_%H%M%S')\n",
+    "WORK_DIR = os.getcwd()\n",
+    "\n",
+    "RESULTS_DIR = f'{OUTPUT_BUCKET}/data/results/{DATESTAMP}/'\n",
+    "ANNOTATED_LIPIDS_GWAS_RESULTS = f'significant_ldl_gwas_results_tbl_gnomad_annotated-{INTERVALS_TO_EXAMINE_NAME}.tsv'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Start Hail "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hl.init(default_reference='GRCh38')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "start_all = datetime.now()\n",
+    "print(start_all)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Read the gnomAD variant annotation table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gnomad = hl.read_table(GNOMAD_TAB)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gnomad.count()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gnomad.describe()\n",
+    "\n",
+    "# Or use this command to view the interactive version of the description.\n",
+    "#gnomad.describe(widget=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Read the lipids GWAS results table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "selvaraj_gwas_results_df = pd.read_excel(SELVARAJ_LIPIDS_GWAS_RESULTS,\n",
+    "                                       sheet_name = 'Supplementary Table 3',\n",
+    "                                       skiprows = 3\n",
+    "                                      )\n",
+    "\n",
+    "selvaraj_gwas_results_df.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Reformat the data for computation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that this particular sheet is well formated for reading, but less so for computation. Results for the various lipids are found within particular row ranges within the spreadsheet."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This is the header row for LDL results.\n",
+    "selvaraj_gwas_results_df.iloc[357,]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This is the header row for total cholesterol results.\n",
+    "selvaraj_gwas_results_df.iloc[697,]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Extract the the subset of rows within the spreadsheet holding just the LDL GWAS results.\n",
+    "ldl_gwas_results_df = selvaraj_gwas_results_df.iloc[359:697,]\n",
+    "\n",
+    "# Fix the data types on the columns.\n",
+    "ldl_gwas_results_df = ldl_gwas_results_df.astype({\n",
+    "    'CHR': 'int64',\n",
+    "    'POS': 'int64',\n",
+    "    'BETA': 'float64',\n",
+    "    'SE': 'float64',\n",
+    "    'p.value': 'float64',\n",
+    "    'MAF': 'float64'\n",
+    "})\n",
+    "\n",
+    "# Add a categorical variable for chromosome.\n",
+    "ldl_gwas_results_df['CHROM'] = pd.Categorical('chr' + ldl_gwas_results_df.CHR.astype('string'),\n",
+    "                                              ordered=True,\n",
+    "                                              categories=[f'chr{i}' for i in range(1, 23)])\n",
+    "\n",
+    "# Sort the dataframe.\n",
+    "ldl_gwas_results_df.sort_values(by=['CHR', 'POS'], inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ldl_gwas_results_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ldl_gwas_results_df.tail()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(ggplot(ldl_gwas_results_df, aes(x = 'CHROM')) +\n",
+    "geom_bar() +\n",
+    "theme_bw()+\n",
+    "theme(figure_size=(16, 8)) +\n",
+    "labs(title = 'Distribution of significant GWAS results per chromosome'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create a Hail table of the GWAS results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Convert the pandas dataframe to a Hail table.\n",
+    "ldl_gwas_results_tbl = hl.Table.from_pandas(\n",
+    "    ldl_gwas_results_df[['CHROM', 'POS', 'Allele1', 'Allele2', 'BETA', 'SE', 'p.value', 'MAF']])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ldl_gwas_results_tbl.count()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create the `locus` and `alleles` fields need to join with Hail matrix tables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ldl_gwas_results_tbl = ldl_gwas_results_tbl.annotate(locus=hl.locus(ldl_gwas_results_tbl.CHROM, ldl_gwas_results_tbl.POS))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ldl_gwas_results_tbl = ldl_gwas_results_tbl.annotate(alleles=hl.array([ldl_gwas_results_tbl.Allele1,\n",
+    "                                                                       ldl_gwas_results_tbl.Allele2]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ldl_gwas_results_tbl = ldl_gwas_results_tbl.key_by(ldl_gwas_results_tbl.locus,\n",
+    "                                                   ldl_gwas_results_tbl.alleles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ldl_gwas_results_tbl.describe()\n",
+    "\n",
+    "# Or use this command to view the interactive version of the description.\n",
+    "#ldl_gwas_results_tbl.describe(widget=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Try to improve performance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Filter gnomAD to include only our genomic intervals of interest"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gnomad.n_partitions()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# First filter using the manually defined intervals.\n",
+    "gnomad = hl.filter_intervals(\n",
+    "    gnomad,\n",
+    "    [hl.parse_locus_interval(x) for x in INTERVALS_TO_EXAMINE],\n",
+    "    keep=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gnomad.n_partitions()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Compute the genomic intervals forming the outer bounds around our GWAS results. We will use this to read fewer partitions from gnomAD.\n",
+    "relevant_intervals_df = ldl_gwas_results_df.groupby('CHR').agg(min_pos=('POS', 'min'), max_pos=('POS', max))\n",
+    "relevant_intervals = relevant_intervals_df.apply(lambda x: f'chr{x.name}:{x[\"min_pos\"]}-{x[\"max_pos\"]+1}', axis=1).tolist()\n",
+    "\n",
+    "relevant_intervals"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Now filter further to only include data overlapping the GWAS results.\n",
+    "gnomad = hl.filter_intervals(\n",
+    "    gnomad,\n",
+    "    [hl.parse_locus_interval(x) for x in relevant_intervals],\n",
+    "    keep=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gnomad.n_partitions()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Repartition to (try to) improve parallelism"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ldl_gwas_results_tbl.n_partitions()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ldl_gwas_results_tbl = ldl_gwas_results_tbl.repartition(ldl_gwas_results_tbl.count())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ldl_gwas_results_tbl.n_partitions()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Annotate significant lipids GWAS results with gnomAD"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Write annotated lipids GWAS results to TSV"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "start = datetime.now()\n",
+    "print(start)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "annotated_ldl_gwas_results_tbl = ldl_gwas_results_tbl.join(gnomad, how='left')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "annotated_ldl_gwas_results_tbl.describe()\n",
+    "\n",
+    "# Or use this command to view the interactive version of the description.\n",
+    "#annotated_ldl_gwas_results_tbl.describe(widget=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "annotated_ldl_gwas_results_tbl.export(os.path.join(RESULTS_DIR, ANNOTATED_LIPIDS_GWAS_RESULTS))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "end = datetime.now()\n",
+    "print(end)\n",
+    "print(end - start)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Examine the ancestry distribution of the GWAS results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gnomad_annotated_ldl_gwas_results_tbl = hl.import_table(os.path.join(RESULTS_DIR, ANNOTATED_LIPIDS_GWAS_RESULTS))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gnomad_annotated_ldl_gwas_results_tbl.describe()\n",
+    "\n",
+    "# Or use this command to view the interactive version of the description.\n",
+    "#gnomad_annotated_ldl_gwas_results_tbl.describe(widget=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gnomad_annotated_ldl_gwas_results_tbl.filter(hl.is_defined(gnomad_annotated_ldl_gwas_results_tbl.popmax)).popmax.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gnomad_annotated_ldl_gwas_results_tbl.aggregate(hl.agg.counter(hl.parse_json(\n",
+    "    gnomad_annotated_ldl_gwas_results_tbl.popmax,\n",
+    "    dtype='struct{AC: int32, AF: float64, AN: int32, homozygote_count: int32, pop: str, faf95: float64}').pop))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Provenance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "end_all = datetime.now()\n",
+    "print(end_all)\n",
+    "print(end_all - start_all)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "process_output = subprocess.run(['pip3', 'freeze'], capture_output=True, text=True)\n",
+    "print(process_output.stdout)"
+   ]
+  }
+ ],
+ "metadata": {
+  "environment": {
+   "kernel": "python3",
+   "name": "r-cpu.4-2.m102",
+   "type": "gcloud",
+   "uri": "gcr.io/deeplearning-platform-release/r-cpu.4-2:m102"
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {
+    "height": "calc(100% - 180px)",
+    "left": "10px",
+    "top": "150px",
+    "width": "445px"
+   },
+   "toc_section_display": true,
+   "toc_window_display": true
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/dataproc/annotate_significant_gwas_results_with_gnomad.ipynb
+++ b/dataproc/annotate_significant_gwas_results_with_gnomad.ipynb
@@ -4,7 +4,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Annotate significant GWAS results with gnomAD"
+    "# Annotate significant GWAS results with gnomAD\n",
+    "\n",
+    "<table align=\"left\">\n",
+    "\n",
+    "  <td>\n",
+    "    <a href=\"https://github.com/DataBiosphere/terra-axon-examples/blob/main/dataproc/annotate_significant_gwas_results_with_gnomad.ipynb\">\n",
+    "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
+    "      View on GitHub\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/DataBiosphere/terra-axon-examples/main/dataproc/annotate_significant_gwas_results_with_gnomad.ipynb\">\n",
+    "      <img src=\"https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksK_vgx40SHs7jCqkTkCk=e14-rj-sc0xffffff-h130-w32\" alt=\"Vertex AI logo\">\n",
+    "      Open in a Terra notebook instance\n",
+    "    </a>\n",
+    "  </td>                                                                                               \n",
+    "</table>"
    ]
   },
   {
@@ -611,6 +627,18 @@
    "source": [
     "process_output = subprocess.run(['pip3', 'freeze'], capture_output=True, text=True)\n",
     "print(process_output.stdout)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "Copyright 2023 Verily Life Sciences LLC\n",
+    "\n",
+    "Use of this source code is governed by a BSD-style   \n",
+    "license that can be found in the LICENSE file or at   \n",
+    "https://developers.google.com/open-source/licenses/bsd"
    ]
   }
  ],

--- a/dataproc/create_hail_cluster.ipynb
+++ b/dataproc/create_hail_cluster.ipynb
@@ -40,7 +40,7 @@
    "metadata": {},
    "source": [
     "<div class=\"alert alert-block alert-info\">\n",
-    "<b>Note:</b> This TVC notebook to creates a Hail cluster, but TVC users can also do this from the terminal or using the Cloud Console UI if they pass the additional configuration needed to install the Hail library.\n",
+    "<b>Note:</b> This TVC notebook creates a Hail cluster, but TVC users can also do this from the terminal or using the Cloud Console UI if they pass the additional configuration needed to install the Hail library.\n",
     "</div>\n"
    ]
   },

--- a/dataproc/create_hail_cluster.ipynb
+++ b/dataproc/create_hail_cluster.ipynb
@@ -5,7 +5,7 @@
    "id": "cb538e08-829b-465c-8313-9833f8f002a9",
    "metadata": {},
    "source": [
-    "# Create a Hail cluster on TVC\n",
+    "# Create a Hail cluster on Enterprise Terra\n",
     "\n",
     "<table align=\"left\">\n",
     "\n",
@@ -31,7 +31,7 @@
    "source": [
     "# Overview\n",
     "\n",
-    "This notebook demonstrates how to create Hail clusters on TVC and submit batch jobs to them. It also discusses how to use JupyterLab on the Hail cluster and access debugging consoles such as the Spark console."
+    "This notebook demonstrates how to create Hail clusters on Enterprise Terra and submit batch jobs to them. It also discusses how to use JupyterLab on the Hail cluster and access debugging consoles such as the Spark console."
    ]
   },
   {
@@ -40,7 +40,7 @@
    "metadata": {},
    "source": [
     "<div class=\"alert alert-block alert-info\">\n",
-    "<b>Note:</b> This TVC notebook creates a Hail cluster, but TVC users can also do this from the terminal or using the Cloud Console UI if they pass the additional configuration needed to install the Hail library.\n",
+    "<b>Note:</b> This Enterprise Terra notebook creates a Hail cluster, but Enterprise Terra users can also do this from the terminal or using the Cloud Console UI if they pass the additional configuration needed to install the Hail library.\n",
     "</div>\n"
    ]
   },
@@ -127,7 +127,7 @@
    "id": "d145af3b-80b8-4457-85a0-e3ef55213475",
    "metadata": {},
    "source": [
-    "Obtain the TVC user's service account. They will act as this same service account when running notebooks or batch scripts on the Dataproc cluster."
+    "Obtain the Enterprise Terra user's service account. They will act as this same service account when running notebooks or batch scripts on the Dataproc cluster."
    ]
   },
   {
@@ -147,7 +147,7 @@
    "id": "49537cb3-20b4-4135-b316-efb95a995172",
    "metadata": {},
    "source": [
-    "Obtain the user name so that it can become part of the Hail cluster name and staging bucket. This is useful when people collaborate in TVC workspaces and want to differentiate their clusters from each other."
+    "Obtain the user name so that it can become part of the Hail cluster name and staging bucket. This is useful when people collaborate in Enterprise Terra workspaces and want to differentiate their clusters from each other."
    ]
   },
   {
@@ -167,7 +167,7 @@
    "id": "1133b444-a427-4a72-a92b-0acb2c146844",
    "metadata": {},
    "source": [
-    "## Check the Terra reference to the Dataproc staging bucket\n",
+    "## Check the Enterprise Terra reference to the Dataproc staging bucket\n",
     "\n",
     "Create the user's Dataproc staging bucket, if it does not yet exist."
    ]
@@ -210,7 +210,7 @@
    "id": "6376d1d7-1016-47b1-8f86-ecb021d147af",
    "metadata": {},
    "source": [
-    "## Check the Terra reference to the Dataproc temp bucket\n",
+    "## Check the Enterprise Terra reference to the Dataproc temp bucket\n",
     "\n",
     "<div class=\"alert alert-block alert-info\">\n",
     "<b>Note:</b> If you did not reach this notebook by duplicating the \"Hail Demo\" workspace, then you will need to first run  <a href=\"https://github.com/DataBiosphere/terra-axon-examples/blob/main/workspace_setup.ipynb\">workspace_setup.ipynb</a>, which is in the parent directory of this notebook.  \n",
@@ -639,7 +639,7 @@
     "## Submit a script to Hail to run\n",
     "\n",
     "<div class=\"alert alert-block alert-info\">\n",
-    "<b>Note:</b> This section uses a TVC notebook to run a Hail batch job, but TVC users can also do this from the terminal or using the Cloud Console UI.\n",
+    "<b>Note:</b> This section uses an Enterprise Terra notebook to run a Hail batch job, but Enterprise Terra users can also do this from the terminal or using the Cloud Console UI.\n",
     "</div>"
    ]
   },

--- a/dataproc/create_hail_cluster.ipynb
+++ b/dataproc/create_hail_cluster.ipynb
@@ -10,13 +10,13 @@
     "<table align=\"left\">\n",
     "\n",
     "  <td>\n",
-    "    <a href=\"https://github.com/verily-src/terra-solutions-mc-terra-testing/blob/main/enable_more_gcp_in_tvc/create_hail_cluster.ipynb\">\n",
+    "    <a href=\"https://github.com/DataBiosphere/terra-axon-examples/blob/main/dataproc/create_hail_cluster.ipynb\">\n",
     "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
     "      View on GitHub\n",
     "    </a>\n",
     "  </td>\n",
     "  <td>\n",
-    "    <a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/DataBiosphere/terra-axon-examples/amyu/dataproc/dataproc/create_hail_cluster.ipynb\">\n",
+    "    <a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/DataBiosphere/terra-axon-examples/main/dataproc/create_hail_cluster.ipynb\">\n",
     "      <img src=\"https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksK_vgx40SHs7jCqkTkCk=e14-rj-sc0xffffff-h130-w32\" alt=\"Vertex AI logo\">\n",
     "      Open in a Terra notebook instance\n",
     "    </a>\n",
@@ -552,7 +552,7 @@
     "\n",
     "However, for Enterprise Terra, it is required to keep the `service-account`, `subnet`, `tags`, and `enable-component-gateway` parameters as is, and retain `JUPYTER` in the `optional-components`. \n",
     "\n",
-    "Additionally, the hail-related values set by the `properties` and `metadata` strings (which, as noted above, are those used by the `hailctl` setup) may not be compatible with changes to some of the other config."
+    "Additionally, the hail-related values set by the `properties` and `metadata` strings (which, as noted above, are the same as those used by the `hailctl` setup) may not be compatible with changes to some of the other config."
    ]
   },
   {

--- a/dataproc/create_hail_cluster.ipynb
+++ b/dataproc/create_hail_cluster.ipynb
@@ -1,0 +1,865 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cb538e08-829b-465c-8313-9833f8f002a9",
+   "metadata": {},
+   "source": [
+    "# Create a Hail cluster on TVC\n",
+    "\n",
+    "<table align=\"left\">\n",
+    "\n",
+    "  <td>\n",
+    "    <a href=\"https://github.com/verily-src/terra-solutions-mc-terra-testing/blob/main/enable_more_gcp_in_tvc/create_hail_cluster.ipynb\">\n",
+    "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
+    "      View on GitHub\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/DataBiosphere/terra-axon-examples/amyu/dataproc/dataproc/create_hail_cluster.ipynb\">\n",
+    "      <img src=\"https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksK_vgx40SHs7jCqkTkCk=e14-rj-sc0xffffff-h130-w32\" alt=\"Vertex AI logo\">\n",
+    "      Open in a Terra notebook instance\n",
+    "    </a>\n",
+    "  </td>                                                                                               \n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "00b3fc9f-d15e-4c48-96e8-b374637ec63a",
+   "metadata": {},
+   "source": [
+    "# Overview\n",
+    "\n",
+    "This notebook demonstrates how to create Hail clusters on TVC and submit batch jobs to them. It also discusses how to use JupyterLab on the Hail cluster and access debugging consoles such as the Spark console."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1694e603-6e51-4903-ada0-b2f7d78f2e82",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<b>Note:</b> This TVC notebook to creates a Hail cluster, but TVC users can also do this from the terminal or using the Cloud Console UI if they pass the additional configuration needed to install the Hail library.\n",
+    "</div>\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "95cb8c98-52ca-45f3-99b3-5b4337c05f9f",
+   "metadata": {
+    "id": "d975e698c9a4"
+   },
+   "source": [
+    "## Objective\n",
+    "\n",
+    "In this tutorial you will learn how to run [Hail](https://hail.is/) via [Dataproc](https://cloud.google.com/dataproc/docs/concepts/overview) with [autoscaling](https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/autoscaling#what_is_autoscaling) for resource management. The steps include:\n",
+    "\n",
+    "1. Gather the necessary configuration for the cluster.\n",
+    "1. Create the Hail cluster.\n",
+    "1. Access JupyterLab and the Spark console running on the cluster.\n",
+    "1. Submit a script to the cluster for Hail to run in batch mode.\n",
+    "\n",
+    "## How to run this notebook\n",
+    "\n",
+    "Run this notebook cell by cell to create and use a Hail cluster.\n",
+    "\n",
+    "## Costs\n",
+    "\n",
+    "This notebook takes less than a minute to run, which will typically cost less than $0.01 of compute time on your cloud environment. This estimate does not include the [cost](https://cloud.google.com/dataproc/pricing) of running the Dataproc cluster."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9bbb95de-c16a-4528-be46-f61445b15a7f",
+   "metadata": {},
+   "source": [
+    "# Setup and Configuration\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6f5b9f2d-41b7-497c-b92d-f5449c8e3f12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7ba8803-aa38-407a-a4a2-6aa5eda6bd7b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not (os.getenv('GOOGLE_CLOUD_PROJECT')\n",
+    "        and os.getenv('GOOGLE_SERVICE_ACCOUNT_EMAIL')\n",
+    "        and os.getenv('TERRA_USER_EMAIL')):\n",
+    "    raise Exception('Expected environment variables are not available. Please let terra-support@verily.com know.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14b47701-4178-45e6-8ed9-3f65a4bbf57e",
+   "metadata": {},
+   "source": [
+    "Obtain the GCP project ID so that it can be used in the name of any buckets we create and also to tell Dataproc where to create the cluster."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bf97da2f-b23c-46dd-af66-f2738dda8472",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PROJECT = os.getenv('GOOGLE_CLOUD_PROJECT')\n",
+    "\n",
+    "PROJECT"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d145af3b-80b8-4457-85a0-e3ef55213475",
+   "metadata": {},
+   "source": [
+    "Obtain the TVC user's service account. They will act as this same service account when running notebooks or batch scripts on the Dataproc cluster."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "78203c21-40bf-4b8a-b2f5-1d352fa1319e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SERVICE_ACCOUNT = os.getenv('GOOGLE_SERVICE_ACCOUNT_EMAIL')\n",
+    "\n",
+    "SERVICE_ACCOUNT"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49537cb3-20b4-4135-b316-efb95a995172",
+   "metadata": {},
+   "source": [
+    "Obtain the user name so that it can become part of the Hail cluster name and staging bucket. This is useful when people collaborate in TVC workspaces and want to differentiate their clusters from each other."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "47735c99-12d4-47c2-b2ae-2e21da4f73cf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "USER = os.getenv('TERRA_USER_EMAIL').split('@')[0].replace('.', '-')\n",
+    "\n",
+    "USER"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1133b444-a427-4a72-a92b-0acb2c146844",
+   "metadata": {},
+   "source": [
+    "## Check the Terra reference to the Dataproc staging bucket\n",
+    "\n",
+    "Create the user's Dataproc staging bucket, if it does not yet exist."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1e9af1d8-64f4-4d1a-ba32-e5eb4eff6565",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!terra resource resolve --name dataproc_staging_{USER} || terra resource create gcs-bucket --name=dataproc_staging_{USER} \\\n",
+    "    --bucket-name={PROJECT}-dataproc-staging-{USER} \\\n",
+    "    --cloning=COPY_NOTHING \\\n",
+    "    --description=\"Bucket for {USER} Dataproc staging files. See https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/staging-bucket\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cdb76aa0-e806-4689-9be9-2ba5a65c2c0d",
+   "metadata": {},
+   "source": [
+    "Resolve the reference to the staging bucket so that we can use it in subsequent commands."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "de31fc7e-b743-4317-8bd0-bfdb0945bbd1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "STAGING_BUCKET_CMD_OUTPUT = !terra resolve --name=dataproc_staging_{USER}\n",
+    "STAGING_BUCKET = STAGING_BUCKET_CMD_OUTPUT[0]\n",
+    "STAGING_BUCKET"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6376d1d7-1016-47b1-8f86-ecb021d147af",
+   "metadata": {},
+   "source": [
+    "## Check the Terra reference to the Dataproc temp bucket\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<b>Note:</b> If you did not reach this notebook by duplicating the \"Hail Demo\" workspace, then you will need to first run  <a href=\"https://github.com/DataBiosphere/terra-axon-examples/blob/main/workspace_setup.ipynb\">workspace_setup.ipynb</a>, which is in the parent directory of this notebook.  \n",
+    "</div>\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce58dc55-88d6-43f7-a18c-1974642ff0ab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!terra resource resolve --name ws_files_autodelete_after_two_weeks || echo Be sure to run workspace_setup.ipynb first before this notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3f847430-e81f-469a-a6ec-227ada825a7c",
+   "metadata": {},
+   "source": [
+    "If the command above gave an error, run `workspace_setup.ipynb` before continuing.  It creates two Cloud Storage buckets for your workspace files with workspace reference names: \n",
+    "\n",
+    " - ws_files   \n",
+    " - ws_files_autodelete_after_two_weeks      \n",
+    "    \n",
+    "This notebook uses the \"autodelete\" bucket as the Dataproc temp bucket. Any file in this bucket will be automatically deleted two weeks after it is written. This alleviates the need for you to remember to clean up temporary and example files manually."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8af59516-abba-412a-8abb-803c8aa882ac",
+   "metadata": {},
+   "source": [
+    "Resolve the reference to the temp bucket so that we can use it in subsequent commands."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d2fe3406-dc7a-44f6-b184-de1f64474f2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TEMP_BUCKET_CMD_OUTPUT = !terra resolve --name=ws_files_autodelete_after_two_weeks\n",
+    "TEMP_BUCKET = TEMP_BUCKET_CMD_OUTPUT[0]\n",
+    "TEMP_BUCKET"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c05391eb-f42c-4b5f-995b-8452db1f292d",
+   "metadata": {},
+   "source": [
+    "## Define an autoscaling policy\n",
+    "\n",
+    "Configure Dataproc [autoscaling](https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/autoscaling) to automatically and dynamically scale the number of worker VMs in Dataproc clusters to meet workload demands.\n",
+    "\n",
+    "People will likely have many different autoscaling policies, since some jobs will run best with different numbers of primary workers that will not be preempted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35d8725e-b32e-4cbe-8285-ab7defe7c13d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile two_worker_autoscaling_policy.yaml\n",
+    "\n",
+    "workerConfig:\n",
+    "  # Best practice: keep min and max values identical for primary workers\n",
+    "  # https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/autoscaling#avoid_scaling_primary_workers\n",
+    "  minInstances: 2\n",
+    "  maxInstances: 2\n",
+    "secondaryWorkerConfig:\n",
+    "  maxInstances: 50\n",
+    "basicAlgorithm:\n",
+    "  cooldownPeriod: 4m\n",
+    "  yarnConfig:\n",
+    "    scaleUpFactor: 0.05\n",
+    "    scaleDownFactor: 1.0\n",
+    "    gracefulDecommissionTimeout: 1h"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49cd9df5-5988-4fd2-b3a6-9c0d40587ea8",
+   "metadata": {},
+   "source": [
+    "Import the autoscaling policy, if it does not yet exist."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce433f11-b715-42f0-8ac5-17d87901b6c0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!gcloud dataproc autoscaling-policies describe two_worker_autoscaling_policy --region=us-central1 || \\\n",
+    "    gcloud dataproc autoscaling-policies import two_worker_autoscaling_policy \\\n",
+    "        --source=two_worker_autoscaling_policy.yaml \\\n",
+    "        --region=us-central1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4138e077-0d37-4ae2-8bd5-6a44d3dc70ee",
+   "metadata": {},
+   "source": [
+    "## Define the Hail initialization script\n",
+    "\n",
+    "This script is based on the logic in [hailctl](https://hail.is/docs/0.2/cloud/google_cloud.html#hailctl-dataproc) version 0.2.108."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a83c0ee2-39fc-47e8-babb-46949b5c05ee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile init_tvc_hail_cluster.py\n",
+    "#!/opt/conda/default/bin/python3\n",
+    "\n",
+    "# This script is based on gs://hail-common/hailctl/dataproc/0.2.108/init_notebook.py with all JupyterLab configuration removed.\n",
+    "\n",
+    "import json\n",
+    "import os\n",
+    "import subprocess as sp\n",
+    "import sys\n",
+    "import errno\n",
+    "from subprocess import check_output\n",
+    "\n",
+    "assert sys.version_info > (3, 0), sys.version_info\n",
+    "\n",
+    "\n",
+    "def safe_call(*args, **kwargs):\n",
+    "    try:\n",
+    "        sp.check_output(args, stderr=sp.STDOUT, **kwargs)\n",
+    "    except sp.CalledProcessError as e:\n",
+    "        print(e.output.decode())\n",
+    "        raise e\n",
+    "\n",
+    "\n",
+    "def get_metadata(key):\n",
+    "    return check_output(['/usr/share/google/get_metadata_value', 'attributes/{}'.format(key)]).decode()\n",
+    "\n",
+    "\n",
+    "def mkdir_if_not_exists(path):\n",
+    "    try:\n",
+    "        os.makedirs(path)\n",
+    "    except OSError as e:\n",
+    "        if e.errno != errno.EEXIST:\n",
+    "            raise\n",
+    "\n",
+    "\n",
+    "# get role of machine (master or worker)\n",
+    "role = get_metadata('dataproc-role')\n",
+    "\n",
+    "if role == 'Master':\n",
+    "    # Additional packages to install.\n",
+    "    # None of these packages should be related to Jupyter or JupyterLab because\n",
+    "    # Dataproc Component Gateway takes care of properly setting up those services.\n",
+    "    pip_pkgs = [\n",
+    "        'setuptools',\n",
+    "        'mkl<2020',\n",
+    "        'lxml<5',\n",
+    "        'https://github.com/hail-is/jgscm/archive/v0.1.12+hail.zip',\n",
+    "    ]\n",
+    "\n",
+    "    # add user-requested packages\n",
+    "    try:\n",
+    "        user_pkgs = get_metadata('PKGS')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    else:\n",
+    "        pip_pkgs.extend(user_pkgs.split('|'))\n",
+    "\n",
+    "    print('pip packages are {}'.format(pip_pkgs))\n",
+    "    command = ['pip', 'install']\n",
+    "    command.extend(pip_pkgs)\n",
+    "    safe_call(*command)\n",
+    "\n",
+    "    print('getting metadata')\n",
+    "\n",
+    "    wheel_path = get_metadata('WHEEL')\n",
+    "    wheel_name = wheel_path.split('/')[-1]\n",
+    "\n",
+    "    print('copying wheel')\n",
+    "    safe_call('gsutil', 'cp', wheel_path, f'/home/hail/{wheel_name}')\n",
+    "\n",
+    "    safe_call('pip', 'install', '--no-dependencies', f'/home/hail/{wheel_name}')\n",
+    "\n",
+    "    print('setting environment')\n",
+    "\n",
+    "    spark_lib_base = '/usr/lib/spark/python/lib/'\n",
+    "    files_to_add = [os.path.join(spark_lib_base, x) for x in os.listdir(spark_lib_base) if x.endswith('.zip')]\n",
+    "\n",
+    "    env_to_set = {\n",
+    "        'PYTHONHASHSEED': '0',\n",
+    "        'PYTHONPATH': ':'.join(files_to_add),\n",
+    "        'SPARK_HOME': '/usr/lib/spark/',\n",
+    "        'PYSPARK_PYTHON': '/opt/conda/default/bin/python',\n",
+    "        'PYSPARK_DRIVER_PYTHON': '/opt/conda/default/bin/python',\n",
+    "        'HAIL_LOG_DIR': '/home/hail',\n",
+    "        'HAIL_DATAPROC': '1',\n",
+    "    }\n",
+    "\n",
+    "    # VEP ENV\n",
+    "    try:\n",
+    "        vep_config_uri = get_metadata('VEP_CONFIG_URI')\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "    else:\n",
+    "        env_to_set[\"VEP_CONFIG_URI\"] = vep_config_uri\n",
+    "\n",
+    "    print('setting environment')\n",
+    "\n",
+    "    for e, value in env_to_set.items():\n",
+    "        safe_call('/bin/sh', '-c',\n",
+    "                  'set -ex; echo \"export {}={}\" | tee -a /etc/environment /usr/lib/spark/conf/spark-env.sh'.format(e,\n",
+    "                                                                                                                   value))\n",
+    "\n",
+    "    hail_jar = sp.check_output([\n",
+    "        '/bin/sh', '-c',\n",
+    "        'set -ex; python3 -m pip show hail | grep Location | sed \"s/Location: //\"'\n",
+    "    ]).decode('ascii').strip() + '/hail/backend/hail-all-spark.jar'\n",
+    "\n",
+    "    conf_to_set = [\n",
+    "        'spark.executorEnv.PYTHONHASHSEED=0',\n",
+    "        'spark.app.name=Hail',\n",
+    "        # the below are necessary to make 'submit' work\n",
+    "        'spark.jars={}'.format(hail_jar),\n",
+    "        'spark.driver.extraClassPath={}'.format(hail_jar),\n",
+    "        'spark.executor.extraClassPath=./hail-all-spark.jar',\n",
+    "    ]\n",
+    "\n",
+    "    print('setting spark-defaults.conf')\n",
+    "\n",
+    "    with open('/etc/spark/conf/spark-defaults.conf', 'a') as out:\n",
+    "        out.write('\\n')\n",
+    "        for c in conf_to_set:\n",
+    "            out.write(c)\n",
+    "            out.write('\\n')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28af1c80-cdac-44db-a884-e1214ba9b192",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!gsutil cp init_tvc_hail_cluster.py {STAGING_BUCKET}/hail/dataproc/0.2.108/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad1e1129-feba-4b88-aefa-1e0cf879a687",
+   "metadata": {},
+   "source": [
+    "## Prepare and copy the example notebook to the staging bucket\n",
+    "\n",
+    "These steps will not be necessary in future.\n",
+    "\n",
+    "Edit the output bucket in the example notebook (temporary work-around):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2666154b-0eb0-4bd5-a5b9-9657419cf945",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TEMPORARY: edit the output bucket in the notebook that will be copied to the cluster. \n",
+    "# Do this since the Dataproc cluster does not currently have the terra cli installed\n",
+    "# to resolve references. This will not be necessary in future.\n",
+    "!cp annotate_significant_gwas_results_with_gnomad.ipynb annotate_significant_gwas_results_with_gnomad_ORIG.ipynb\n",
+    "\n",
+    "with open('annotate_significant_gwas_results_with_gnomad_ORIG.ipynb', 'rt') as fin:\n",
+    "    with open('annotate_significant_gwas_results_with_gnomad.ipynb', 'wt') as fout:\n",
+    "        for line in fin:\n",
+    "            fout.write(line.replace(\"os.getenv('WORKSPACE_BUCKET')\",\n",
+    "                                    f\"'{STAGING_BUCKET}'\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5c1ece04-501c-46ab-b3eb-aea78c6b4c22",
+   "metadata": {},
+   "source": [
+    "Copy the notebook to the staging bucket (temporary work-around):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "42c69b74-009b-46bf-adf2-96f62406e15a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TEMPORARY: copy the notebook from the git clone. Do this since the Dataproc cluster does \n",
+    "# not currently clone the git repos referenced in this workspace.\n",
+    "!gsutil cp annotate_significant_gwas_results_with_gnomad.ipynb {STAGING_BUCKET}/notebooks/jupyter/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "faaa5b49-9b77-4bb6-92b8-c1604bd9a1fe",
+   "metadata": {},
+   "source": [
+    "# Create a Dataproc cluster where we will run Hail\n",
+    "\n",
+    "The values within `--properties` and `--metadata` in the command line below are based on what is generated by https://hail.is/docs/0.2/cloud/google_cloud.html#hailctl-dataproc. But two extra packages were added in support of the gnomAD notebook: `plotnine` and `openpyxl`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a2f57e2a-c198-45fd-84c3-5254a18dbe73",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "HAIL_CLUSTER_NAME = '-'.join(['hail', USER, datetime.now().strftime('%Y%m%d')])\n",
+    "\n",
+    "HAIL_CLUSTER_NAME"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "891850b6-bd83-42c4-a9c6-dfc4a5e90683",
+   "metadata": {},
+   "source": [
+    "Run the command to create the cluster.  If you like, you can modify many of these properties.\n",
+    "See [this page](https://cloud.google.com/sdk/gcloud/reference/dataproc/clusters/create) for more detail on the available options.\n",
+    "\n",
+    "However, for Enterprise Terra, it is required to keep the `service-account`, `subnet`, `tags`, and `enable-component-gateway` parameters as is, and retain `JUPYTER` in the `optional-components`. \n",
+    "\n",
+    "Additionally, the hail-related values set by the `properties` and `metadata` strings (which, as noted above, are those used by the `hailctl` setup) may not be compatible with changes to some of the other config."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "06e41262-7bc4-4865-8b1e-7b9c7c52e393",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!gcloud dataproc clusters create {HAIL_CLUSTER_NAME} \\\n",
+    "    --region us-central1 \\\n",
+    "    --image-version=2.0.44-debian10 \\\n",
+    "    --properties='^|||^spark:spark.task.maxFailures=20|||spark:spark.driver.extraJavaOptions=-Xss4M|||spark:spark.executor.extraJavaOptions=-Xss4M|||spark:spark.speculation=true|||hdfs:dfs.replication=1|||dataproc:dataproc.logging.stackdriver.enable=false|||dataproc:dataproc.monitoring.stackdriver.enable=false|||spark:spark.driver.memory=12g|||yarn:yarn.nodemanager.resource.memory-mb=14592|||yarn:yarn.scheduler.maximum-allocation-mb=14592|||spark:spark.executor.cores=4|||spark:spark.executor.memory=5837m|||spark:spark.executor.memoryOverhead=8755m|||spark:spark.memory.storageFraction=0.2|||spark:spark.executorEnv.HAIL_WORKER_OFF_HEAP_MEMORY_PER_CORE_MB=3648' \\\n",
+    "    --initialization-actions={STAGING_BUCKET}/hail/dataproc/0.2.108/init_tvc_hail_cluster.py \\\n",
+    "    --metadata='^|||^WHEEL=gs://hail-common/hailctl/dataproc/0.2.105/hail-0.2.105-py3-none-any.whl|||PKGS=openpyxl==3.0.10|plotnine==0.10.1|aiohttp>=3.8.1,<4|aiohttp_session>=2.7,<2.8|asyncinit>=0.2.4,<0.3|avro>=1.10,<1.12|azure-identity>=1.6.0,<2|azure-storage-blob>=12.11.0,<13|bokeh>1.3,<2.0|boto3>=1.17,<2.0|botocore>=1.20,<2.0|decorator<5|Deprecated>=1.2.10,<1.3|dill>=0.3.1.1,<0.4|google-auth>=1.27.0,<2|frozenlist>=1.3.1,<2|google-cloud-storage==1.25.*|humanize>=1.0.0,<2|hurry.filesize>=0.9,<1|janus>=0.6,<1.1|Jinja2==3.0.3|nest_asyncio>=1.5.4,<2|numpy<2|orjson>=3.6.4,<4|pandas>=1.3.0,<1.5.0|parsimonious<0.9|plotly>=5.5.0,<5.11|protobuf==3.20.2|PyJWT|rich==12.6.0|python-json-logger>=2.0.2,<3|requests>=2.25.1,<3|scipy>1.2,<1.10|sortedcontainers>=2.4.0,<3|tabulate>=0.8.9,<1|uvloop>=0.16.0,<1' \\\n",
+    "    --master-machine-type n1-standard-4 \\\n",
+    "    --master-boot-disk-size 100 \\\n",
+    "    --autoscaling-policy two_worker_autoscaling_policy \\\n",
+    "    --num-workers 2 \\\n",
+    "    --worker-machine-type n1-standard-4 \\\n",
+    "    --worker-boot-disk-size 100 \\\n",
+    "    --num-secondary-workers 0 \\\n",
+    "    --secondary-worker-machine-type n1-standard-4 \\\n",
+    "    --secondary-worker-boot-disk-size 100 \\\n",
+    "    --enable-component-gateway \\\n",
+    "    --optional-components JUPYTER \\\n",
+    "    --service-account {SERVICE_ACCOUNT} \\\n",
+    "    --subnet projects/{PROJECT}/regions/us-central1/subnetworks/subnetwork \\\n",
+    "    --tags leonardo \\\n",
+    "    --bucket {STAGING_BUCKET[len('gs://'):]} \\\n",
+    "    --temp-bucket {TEMP_BUCKET[len('gs://'):]} \\\n",
+    "    --max-idle 30m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b860d05f-0788-4e4e-b402-3dda1abb7c17",
+   "metadata": {},
+   "source": [
+    "The cluster will take a few minutes to start up."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "73de7bc8-c2ac-46bd-9587-5f88cca60265",
+   "metadata": {},
+   "source": [
+    "## Access JupterLab and the debugging consoles\n",
+    "\n",
+    "You can use the URL printed by the next cell to access JupyterLab running on the cluster. See also the URLs to the debuging consoles such as the Spark Console.\n",
+    "\n",
+    "Or if you would like to use the Cloud Console to obtain these URLs:\n",
+    "* Go to the Cloud Console -> Dataproc -> Clusters\n",
+    "* Select the cluster on which you want to run the notebook\n",
+    "* Click on tab 'WEB INTERFACES'\n",
+    "* Click on 'JupyterLab'\n",
+    "\n",
+    "Lastly, CPU utilization, memory utlization, and other performance metrics for the cluster are available on the Cloud Console. Click on the cluster name to see the plots of these metrics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c5d3c60c-b616-45e7-b1be-c3cc8625d7fc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!gcloud dataproc clusters describe {HAIL_CLUSTER_NAME} --region=us-central1 --format=\"yaml(config.endpointConfig.httpPorts)\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5433c41f-bf2d-4b5e-b980-56de0d32e282",
+   "metadata": {},
+   "source": [
+    "# Use Hail on the cluster"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ee2784b-aecd-494c-962b-e7804dda0e2a",
+   "metadata": {},
+   "source": [
+    "## Submit a script to Hail to run\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<b>Note:</b> This section uses a TVC notebook to run a Hail batch job, but TVC users can also do this from the terminal or using the Cloud Console UI.\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "be82b011-c694-4431-ad0b-d96d5cde767a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!jupyter nbconvert --to script annotate_significant_gwas_results_with_gnomad.ipynb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "81670113-fe3f-42af-898a-4514e52344bf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!gcloud dataproc jobs submit pyspark --cluster {HAIL_CLUSTER_NAME} --region us-central1 \\\n",
+    "    annotate_significant_gwas_results_with_gnomad.py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d99af242-f2c4-444b-96d1-7635d8ff1c90",
+   "metadata": {},
+   "source": [
+    "Once the job is running (or after it has finished), you can view the [cluster dashboard](https://cloud.console.google.com/dataproc) (click in to view detail for each cluster) and the [job info](https://console.cloud.google.com/dataproc/jobs), including job logs, in the Google Cloud console. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "75c1152e-aa03-4644-9127-1dec3c33fded",
+   "metadata": {},
+   "source": [
+    "## Use Hail interactively on the cluster's JupyterLab server\n",
+    "\n",
+    "In the output of the section \"Access JupterLab and the debugging consoles\" above, click the **JupyterLab** link. \n",
+    "You can alternately find this link under the **WEB INTERFACES** tab when you click in to the details for your cluster in the [Cloud Console](https://cloud.console.google.com/dataproc).\n",
+    "\n",
+    "Open the `annotate_significant_gwas_results_with_gnomad.ipynb` notebook, which is available on the cluster's JupyterLab server because we copied it to `{STAGING_BUCKET}/notebooks/jupyter/`. \n",
+    "\n",
+    "In the notebook, you may want to try setting the `INTERVALS_TO_EXAMINE` constant to `['chr1-chr22']`, to run at scale.  This should cause the cluster's *autoscaling* to kick in.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "077e93b1-cd24-4e04-b21a-c5ffa61bf91e",
+   "metadata": {},
+   "source": [
+    "# Stop or delete your cluster when you are finished\n",
+    "\n",
+    "You can use the next cell to stop the cluster; or your cluster will automatically be deleted after `max-idle` (default 30) minutes of inactivity.\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<b>Note:</b> If autoscaling has been initiated, it may not be possible to `STOP` the cluster, only to `DELETE` it.<br/>   \n",
+    "    Even if your cluster has been stopped, it will still delete itself after `max-idle` minutes of inactivity.\n",
+    "</div>\n",
+    "\n",
+    "Alternately, if you would like to use the Cloud Console to stop or delete the cluster:\n",
+    "* Go to the Cloud Console -> Dataproc -> Clusters\n",
+    "* Select the cluster on which you want to stop or delete\n",
+    "* Click on 'Stop' or 'Delete'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c7a952dc-a864-438c-b52a-9746aa4bf064",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!gcloud dataproc clusters stop {HAIL_CLUSTER_NAME} --region=us-central1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a0d11957-e86d-49ce-b856-7047332404b7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# UNCOMMENT this command if you want to also delete the cluster.\n",
+    "\n",
+    "#!gcloud dataproc clusters delete {HAIL_CLUSTER_NAME} --region=us-central1 --quiet"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0cfe1af0-b830-4030-929a-9829b799bf12",
+   "metadata": {},
+   "source": [
+    "# Provenance\n",
+    "\n",
+    "Generate information about this notebook environment and the packages installed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "282ed3c2-8b95-4e03-ac0c-0340deedf908",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!date"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ab271e3-cd8a-4a36-85dc-bde44388a1df",
+   "metadata": {},
+   "source": [
+    "Conda and pip installed packages:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1333dcf8-9de7-4f77-84cf-09ee014d9b9f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!conda env export"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7894537c-a506-49e1-8945-1b6338eb007f",
+   "metadata": {},
+   "source": [
+    "JupyterLab extensions:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0fa42a49-ab93-43db-8651-29ce173996d7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!jupyter labextension list"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "89ab5085-17f6-4d4a-bdcc-6e69c0287463",
+   "metadata": {},
+   "source": [
+    "Number of cores:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31247055-40ab-4d92-9bab-44c563319cd7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!grep ^processor /proc/cpuinfo | wc -l"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d103ed4b-d3f1-431d-abee-7dea15fd3f42",
+   "metadata": {},
+   "source": [
+    "Memory:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0af40197-0fa2-4740-a5c4-4d344c81c6dc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!grep \"^MemTotal:\" /proc/meminfo"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae2394d0-1196-4efb-b6eb-484083ecd4ee",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "Copyright 2023 Verily Life Sciences LLC\n",
+    "\n",
+    "Use of this source code is governed by a BSD-style   \n",
+    "license that can be found in the LICENSE file or at   \n",
+    "https://developers.google.com/open-source/licenses/bsd"
+   ]
+  }
+ ],
+ "metadata": {
+  "environment": {
+   "kernel": "python3",
+   "name": "r-cpu.4-2.m103",
+   "type": "gcloud",
+   "uri": "gcr.io/deeplearning-platform-release/r-cpu.4-2:m103"
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/dataproc/create_hail_cluster.ipynb
+++ b/dataproc/create_hail_cluster.ipynb
@@ -179,7 +179,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!terra resource resolve --name dataproc_staging_{USER} || terra resource create gcs-bucket --name=dataproc_staging_{USER} \\\n",
+    "!terra resource resolve --name dataproc_staging_{USER} || terra resource create gcs-bucket \\\n",
+    "    --name=dataproc_staging_{USER} \\\n",
     "    --bucket-name={PROJECT}-dataproc-staging-{USER} \\\n",
     "    --cloning=COPY_NOTHING \\\n",
     "    --description=\"Bucket for {USER} Dataproc staging files. See https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/staging-bucket\""
@@ -213,7 +214,7 @@
     "## Check the Enterprise Terra reference to the Dataproc temp bucket\n",
     "\n",
     "<div class=\"alert alert-block alert-info\">\n",
-    "<b>Note:</b> If you did not reach this notebook by duplicating the \"Hail Demo\" workspace, then you will need to first run  <a href=\"https://github.com/DataBiosphere/terra-axon-examples/blob/main/workspace_setup.ipynb\">workspace_setup.ipynb</a>, which is in the parent directory of this notebook.  \n",
+    "<b>Note:</b> This notebook assumes that <a href=\"https://github.com/DataBiosphere/terra-axon-examples/blob/main/workspace_setup.ipynb\">workspace_setup.ipynb</a>, which is in the parent directory of this notebook, has been run.  \n",
     "</div>\n"
    ]
   },
@@ -224,7 +225,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!terra resource resolve --name ws_files_autodelete_after_two_weeks || echo Be sure to run workspace_setup.ipynb first before this notebook."
+    "!terra resource resolve --name ws_files_autodelete_after_two_weeks || echo Be sure to run \\\n",
+    "  workspace_setup.ipynb first before this notebook."
    ]
   },
   {
@@ -337,7 +339,8 @@
     "%%writefile init_tvc_hail_cluster.py\n",
     "#!/opt/conda/default/bin/python3\n",
     "\n",
-    "# This script is based on gs://hail-common/hailctl/dataproc/0.2.108/init_notebook.py with all JupyterLab configuration removed.\n",
+    "# This script is based on gs://hail-common/hailctl/dataproc/0.2.108/init_notebook.py with all \n",
+    "# JupyterLab configuration removed.\n",
     "\n",
     "import json\n",
     "import os\n",
@@ -620,7 +623,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gcloud dataproc clusters describe {HAIL_CLUSTER_NAME} --region=us-central1 --format=\"yaml(config.endpointConfig.httpPorts)\""
+    "!gcloud dataproc clusters describe {HAIL_CLUSTER_NAME} --region=us-central1 \\\n",
+    "  --format=\"yaml(config.endpointConfig.httpPorts)\""
    ]
   },
   {

--- a/dataproc/hail_demo_dashboard.md
+++ b/dataproc/hail_demo_dashboard.md
@@ -1,0 +1,35 @@
+# Overview
+
+This workspace shows how to start a [Dataproc](https://cloud.google.com/dataproc) (managed Spark) cluster, with Hail installed, on Enterprise Terra, and how to submit batch jobs to the cluster as well as how to run an interactive notebook on the Hail cluster.
+
+It uses an example that annotates significant GWAS results with gnomAD using [Hail](https://hail.is/).  
+
+The example specifically annotates GWAS results from the paper [*Whole genome sequence analysis of blood lipid levels in >66,000 individuals. Selvaraj et al 2021*](https://www.biorxiv.org/content/10.1101/2021.10.11.463514v1.supplementary-material). There are only 338 significant LDL results to annotate, so it might be faster to annotate using a tool other than Hail, but this workspace is meant to be illustrative and run on publicly available data.
+
+# How do I get started?
+
+*Duplicate* this workspace. You can do that via the 'three-dot' menu in the upper right of the workspace. 
+
+
+## Step 1: Preview prior runs of the relevant notebooks.
+
+On the 'Resources' page, navigate to TVC folder "Notebook snapshots" and preview the notebooks you see there in this order to get a deeper understanding of what setup and analysis this demonstration workspace enables:
+1. `workspace_setup.ipynb` (This notebook was run as part of the "Hail Demo" workspace creation, and you do not need to run it again in your duplicated workspace).
+2. `create_hail_cluster.ipynb`
+3. `annotate_significant_gwas_results_with_gnomad_brief.ipynb`, which was run on a small region of the genome
+4. `annotate_significant_gwas_results_with_gnomad_at_scale.ipynb`, which was run on all autosomes
+
+
+## Step 2: Create your own Hail cluster.
+
+Create an Enterprise Terra Cloud environment, by navigating to the "Environments" tab of the workspace. You can use the configuration defaults.
+
+Launch the environment once it's running, and then run the notebook `create_hail_cluster.ipynb` to create your Hail cluster. You will find this notebook in [https://github.com/DataBiosphere/terra-axon-examples/tree/main/dataproc](https://github.com/https://github.com/DataBiosphere/terra-axon-examples/tree/main/dataproc).  This repo, which is defined as a workspace Git repository, will be automatically cloned to your Enterprise Terra Cloud Environment, and you should be able to navigate to the notebook in the JupyterLab file browser.
+
+## Step 3: Use the Hail cluster to run a brief analysis.
+
+Notebook `create_hail_cluster.ipynb` provides instructions on how to run `annotate_significant_gwas_results_with_gnomad.ipynb`, which resides in the same directory, as either a batch script or as an interactive Jupyter notebook on the Hail cluster.
+
+## Step 4: Use the Hail cluster to run the analysis at scale!
+
+With notebook `annotate_significant_gwas_results_with_gnomad.ipynb`, you can also control how much data it uses as input so that it either completes briefly (e.g. 5 minutes) or runs longer (e.g. 30 minutes). Edit variable `INTERVALS_TO_EXAMINE` to have value `['chr1-chr22']` in either the script or notebook version of the analysis so that you can observe autoscaling and cluster metrics as it runs.

--- a/dataproc/hail_demo_dashboard.md
+++ b/dataproc/hail_demo_dashboard.md
@@ -2,18 +2,18 @@
 
 This workspace shows how to start a [Dataproc](https://cloud.google.com/dataproc) (managed Spark) cluster, with Hail installed, on Enterprise Terra, and how to submit batch jobs to the cluster as well as how to run an interactive notebook on the Hail cluster.
 
-It uses an example that annotates significant GWAS results with gnomAD using [Hail](https://hail.is/).  
+It uses an example that annotates significant GWAS results with gnomAD using [Hail](https://hail.is/).
 
 The example specifically annotates GWAS results from the paper [*Whole genome sequence analysis of blood lipid levels in >66,000 individuals. Selvaraj et al 2021*](https://www.biorxiv.org/content/10.1101/2021.10.11.463514v1.supplementary-material). There are only 338 significant LDL results to annotate, so it might be faster to annotate using a tool other than Hail, but this workspace is meant to be illustrative and run on publicly available data.
 
 # How do I get started?
 
-*Duplicate* this workspace. You can do that via the 'three-dot' menu in the upper right of the workspace. 
+*Duplicate* this workspace. You can do that via the 'three-dot' menu in the upper right of the workspace.
 
 
 ## Step 1: Preview prior runs of the relevant notebooks.
 
-On the 'Resources' page, navigate to TVC folder "Notebook snapshots" and preview the notebooks you see there in this order to get a deeper understanding of what setup and analysis this demonstration workspace enables:
+On the 'Resources' page, navigate to the Enterprise Terra folder "Notebook snapshots" and preview the notebooks you see there in this order to get a deeper understanding of what setup and analysis this demonstration workspace enables:
 1. `workspace_setup.ipynb` (This notebook was run as part of the "Hail Demo" workspace creation, and you do not need to run it again in your duplicated workspace).
 2. `create_hail_cluster.ipynb`
 3. `annotate_significant_gwas_results_with_gnomad_brief.ipynb`, which was run on a small region of the genome

--- a/dataproc/hail_demo_dashboard.md
+++ b/dataproc/hail_demo_dashboard.md
@@ -14,22 +14,26 @@ The example specifically annotates GWAS results from the paper [*Whole genome se
 ## Step 1: Preview prior runs of the relevant notebooks.
 
 On the 'Resources' page, navigate to the Enterprise Terra folder "Notebook snapshots" and preview the notebooks you see there in this order to get a deeper understanding of what setup and analysis this demonstration workspace enables:
-1. `workspace_setup.ipynb` (This notebook was run as part of the "Hail Demo" workspace creation, and you do not need to run it again in your duplicated workspace).
+1. `workspace_setup.ipynb`
 2. `create_hail_cluster.ipynb`
 3. `annotate_significant_gwas_results_with_gnomad_brief.ipynb`, which was run on a small region of the genome
 4. `annotate_significant_gwas_results_with_gnomad_at_scale.ipynb`, which was run on all autosomes
 
 
-## Step 2: Create your own Hail cluster.
+## Step 2: Create an Enterprise Terra Cloud Environment and run a setup notebook.
 
 Create an Enterprise Terra Cloud environment, by navigating to the "Environments" tab of the workspace. You can use the configuration defaults.
 
-Launch the environment once it's running, and then run the notebook `create_hail_cluster.ipynb` to create your Hail cluster. You will find this notebook in [https://github.com/DataBiosphere/terra-axon-examples/tree/main/dataproc](https://github.com/https://github.com/DataBiosphere/terra-axon-examples/tree/main/dataproc).  This repo, which is defined as a workspace Git repository, will be automatically cloned to your Enterprise Terra Cloud Environment, and you should be able to navigate to the notebook in the JupyterLab file browser.
+Launch the environment once it's running, and then run the notebook [workspace_setup.ipynb](https://github.com/DataBiosphere/terra-axon-examples/blob/main/workspace_setup.ipynb). Its repo, `terra-axon-examples`, which is defined as a workspace Git repository, will be automatically cloned to your Enterprise Terra Cloud Environments, and you should be able to navigate to the notebook in the JupyterLab file browser. Look for the `terra-axon-examples` subdirectory.
 
-## Step 3: Use the Hail cluster to run a brief analysis.
+## Step 3: Create your own Hail cluster.
+
+Run the notebook `create_hail_cluster.ipynb` to create your Hail cluster. You will find this notebook in [https://github.com/DataBiosphere/terra-axon-examples/tree/main/dataproc](https://github.com/https://github.com/DataBiosphere/terra-axon-examples/tree/main/dataproc).  As mentioned above, its repo, `terra-axon-examples`, will be automatically cloned to your Enterprise Terra Cloud Environment, and you should be able to navigate to the notebook in the JupyterLab file browser.
+
+## Step 4: Use the Hail cluster to run a brief analysis.
 
 Notebook `create_hail_cluster.ipynb` provides instructions on how to run `annotate_significant_gwas_results_with_gnomad.ipynb`, which resides in the same directory, as either a batch script or as an interactive Jupyter notebook on the Hail cluster.
 
-## Step 4: Use the Hail cluster to run the analysis at scale!
+## Step 5: Use the Hail cluster to run the analysis at scale!
 
 With notebook `annotate_significant_gwas_results_with_gnomad.ipynb`, you can also control how much data it uses as input so that it either completes briefly (e.g. 5 minutes) or runs longer (e.g. 30 minutes). Edit variable `INTERVALS_TO_EXAMINE` to have value `['chr1-chr22']` in either the script or notebook version of the analysis so that you can observe autoscaling and cluster metrics as it runs.


### PR DESCRIPTION
... and make some updates & add additional text for sharing externally. 
I expect you may have some comments on how to best phrase some stuff I added, plus there may be some more spots that need additional explanation.

Some things to note:
- the links at the top of the notebooks (viewing in GH + importing to a nb vm) are for when this branch is merged into in `main`.  I'll double check them then to make sure I didn't make a mistake.
- There shouldn't be any code changes, only markdown cell changes (& description .md changes). However, this PR doesn't show a direct diff with the originals from the other repo (sorry, didn't think ahead)
- I will also create a prod workspace that they will _duplicate_ (this is the current terminology over 'clone' IIUC) to create their own. It will have the buckets created and the GH repo added. 

I haven't yet tested this in prod (dataproc enablement just landed today) but will shortly. 
