### PR TITLE
Set 16M as the default max-allowed-packet. Fix naming convention assumptions. 

### DIFF
--- a/cromwell_setup/cromwell_gvs_setup_inputs.ipynb
+++ b/cromwell_setup/cromwell_gvs_setup_inputs.ipynb
@@ -39,17 +39,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "NUM_OF_INPUTS = 8022  # CHANGE THIS NUMBER!\n",
-    "CALLSET_IDENTIFIER = 'willyn_8022_samples_1'  # CHANGE THIS NAME! \n",
+    "NUM_OF_INPUTS = 300  # CHANGE THIS NUMBER!\n",
+    "CALLSET_IDENTIFIER = '300_samples_batch_id'  # CHANGE THIS NAME! \n",
     "\n",
-    "# Change this if the source location of input changes\n",
-    "INPUT_SOURCE = 'gs://cloned-ws-files-terra-happy-plum-360/s3-to-gcg/SRA9350'\n",
+    "# CHANGE THIS SOURCE LOCATION OF INPUT FILES\n",
+    "INPUT_SOURCE = 'gs://{EXAMPLE_BUCKET}/PATH/TO/SAMPLES'\n",
+    "\n",
+    "# CHANGE THIS TO NAME YOUR BQ DATASET\n",
+    "GVS_BQ_DATASET = 'gvs_300'\n",
     "\n",
     "MAIN_WORKFLOW = \"GvsJointVariantCalling\"\n",
     "WDL_FILE = f\"{MAIN_WORKFLOW}.wdl\"\n",
     "\n",
-    "GOOGLE_CLOUD_PROJECT = os.getenv('GOOGLE_CLOUD_PROJECT')\n",
-    "GVS_BQ_DATASET = 'gvs_8022'"
+    "GOOGLE_CLOUD_PROJECT = os.getenv('GOOGLE_CLOUD_PROJECT')"
    ]
   },
   {

--- a/cromwell_setup/cromwell_gvs_setup_inputs.ipynb
+++ b/cromwell_setup/cromwell_gvs_setup_inputs.ipynb
@@ -39,17 +39,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "NUM_OF_INPUTS = 300  # CHANGE THIS NUMBER!\n",
-    "CALLSET_IDENTIFIER = 'willyn_300_samples_2'  # CHANGE THIS NAME! \n",
+    "NUM_OF_INPUTS = 8022  # CHANGE THIS NUMBER!\n",
+    "CALLSET_IDENTIFIER = 'willyn_8022_samples_1'  # CHANGE THIS NAME! \n",
     "\n",
     "# Change this if the source location of input changes\n",
-    "INPUT_SOURCE = 'gs://cloned-ws-files-terra-happy-plum-360/SRA8739/trujila6_ehive_rosaprd_2852'\n",
+    "INPUT_SOURCE = 'gs://cloned-ws-files-terra-happy-plum-360/s3-to-gcg/SRA9350'\n",
     "\n",
     "MAIN_WORKFLOW = \"GvsJointVariantCalling\"\n",
     "WDL_FILE = f\"{MAIN_WORKFLOW}.wdl\"\n",
     "\n",
     "GOOGLE_CLOUD_PROJECT = os.getenv('GOOGLE_CLOUD_PROJECT')\n",
-    "GVS_BQ_DATASET = 'gvs_testing'"
+    "GVS_BQ_DATASET = 'gvs_8022'"
    ]
   },
   {
@@ -109,7 +109,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "input_source_list = !gsutil ls {INPUT_SOURCE}"
+    "# The gsutil ls call returns a list containing all the vcf.gz and vcf.gz.tbi files. Lets pull out all the vcf.gz files.\n",
+    "input_source_list = !gsutil ls \"{INPUT_SOURCE}/**\"\n",
+    "input_source_list = [input_source for input_source in input_source_list if input_source.endswith('vcf.gz')]"
    ]
   },
   {
@@ -123,10 +125,10 @@
     "input_vcf_indexes = []\n",
     "sample_names = []\n",
     "\n",
-    "for input_source in input_source_list[:NUM_OF_INPUTS]:\n",
-    "    sample_name = input_source.split('/')[-2]\n",
-    "    input_vcfs.append(f'{input_source}{sample_name}.g.vcf.gz')\n",
-    "    input_vcf_indexes.append(f'{input_source}{sample_name}.g.vcf.gz.tbi')\n",
+    "for vcf_path in input_source_list[:NUM_OF_INPUTS]:\n",
+    "    sample_name = vcf_path.split('/')[-2]\n",
+    "    input_vcfs.append(vcf_path)\n",
+    "    input_vcf_indexes.append(f'{vcf_path}.tbi')\n",
     "    sample_names.append(sample_name)"
    ]
   },
@@ -331,9 +333,9 @@
  "metadata": {
   "environment": {
    "kernel": "python3",
-   "name": "r-cpu.4-2.m103",
+   "name": "r-cpu.4-2.m104",
    "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/r-cpu.4-2:m103"
+   "uri": "gcr.io/deeplearning-platform-release/r-cpu.4-2:m104"
   },
   "kernelspec": {
    "display_name": "Python 3",

--- a/cromwell_setup/cromwell_gvs_setup_inputs.ipynb
+++ b/cromwell_setup/cromwell_gvs_setup_inputs.ipynb
@@ -39,6 +39,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# This notebook will run the GVS workflow on the first NUM_OF_INPUTS samples in the INPUT_SOURCE location\n",
     "NUM_OF_INPUTS = 300  # CHANGE THIS NUMBER!\n",
     "CALLSET_IDENTIFIER = '300_samples_batch_id'  # CHANGE THIS NAME! \n",
     "\n",

--- a/cromwell_setup/cromwell_server_management.ipynb
+++ b/cromwell_setup/cromwell_server_management.ipynb
@@ -167,7 +167,8 @@
     "    -e MYSQL_DATABASE=cromwell_db \\\n",
     "    -e MYSQL_USER=cromwell \\\n",
     "    -e MYSQL_PASSWORD=cromwell \\\n",
-    "    -d mysql/mysql-server:5.5"
+    "    -d mysql/mysql-server:5.5 \\\n",
+    "    --max-allowed-packet=16M"
    ]
   },
   {
@@ -384,16 +385,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!tail -n 5 {CROMWELL_SERVER_LOG}"
+    "!tail -n 15 {CROMWELL_SERVER_LOG}"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7ff60d2c-fe37-4bed-b353-2b0499b3ca38",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "environment": {
    "kernel": "python3",
-   "name": "r-cpu.4-2.m103",
+   "name": "r-cpu.4-2.m104",
    "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/r-cpu.4-2:m103"
+   "uri": "gcr.io/deeplearning-platform-release/r-cpu.4-2:m104"
   },
   "kernelspec": {
    "display_name": "Python 3",

--- a/cromwell_setup/cromwell_server_management.ipynb
+++ b/cromwell_setup/cromwell_server_management.ipynb
@@ -387,14 +387,6 @@
    "source": [
     "!tail -n 5 {CROMWELL_SERVER_LOG}"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7ff60d2c-fe37-4bed-b353-2b0499b3ca38",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/cromwell_setup/cromwell_server_management.ipynb
+++ b/cromwell_setup/cromwell_server_management.ipynb
@@ -385,7 +385,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!tail -n 15 {CROMWELL_SERVER_LOG}"
+    "!tail -n 5 {CROMWELL_SERVER_LOG}"
    ]
   },
   {


### PR DESCRIPTION
While attempting to submit an 8000-sample run, I saw Cromwell show an error `Packet for query is too large (1759687 > 1048576). You can change this value on the server by setting the max_allowed_packet' variable.` This error comes from MySQL server. Most documentation I've read online say 16M is a typical default, but 1048576 looks more like 1MB to me. 

This PR also includes some code changes that makes it less assuming of filename conventions. 