### PR TITLE
Check in changes for GVS scaled up to 50k samples

### DIFF
--- a/cromwell_setup/cromwell_gvs_setup_inputs.ipynb
+++ b/cromwell_setup/cromwell_gvs_setup_inputs.ipynb
@@ -49,6 +49,9 @@
     "# CHANGE THIS TO NAME YOUR BQ DATASET\n",
     "GVS_BQ_DATASET = 'gvs_300'\n",
     "\n",
+    "# Change this to False to remove throttling applied to \"beta\" users\n",
+    "IS_BETA_USER = True\n",
+    "\n",
     "MAIN_WORKFLOW = \"GvsJointVariantCalling\"\n",
     "WDL_FILE = f\"{MAIN_WORKFLOW}.wdl\"\n",
     "\n",
@@ -148,7 +151,12 @@
     "    'GvsJointVariantCalling.external_sample_names': sample_names,\n",
     "    'GvsJointVariantCalling.dataset_name': GVS_BQ_DATASET,\n",
     "    'GvsJointVariantCalling.input_vcf_indexes': input_vcf_indexes,\n",
-    "    'GvsJointVariantCalling.project_id': GOOGLE_CLOUD_PROJECT\n",
+    "    'GvsJointVariantCalling.project_id': GOOGLE_CLOUD_PROJECT,\n",
+    "    'GvsJointVariantCalling.is_beta_user': IS_BETA_USER,\n",
+    "    'GvsJointVariantCalling.load_data_batch_size': 5,\n",
+    "    'GvsJointVariantCalling.max_sleep_minutes': 120,\n",
+    "    'GvsJointVariantCalling.INDEL_VQSR_mem_gb_override': 300,\n",
+    "    'GvsJointVariantCalling.SNP_VQSR_mem_gb_override': 624\n",
     "}\n",
     "\n",
     "with open('gvs.inputs', 'w') as outfile:\n",
@@ -173,7 +181,10 @@
    "outputs": [],
    "source": [
     "with open('gvs_options.json', 'w') as outfile:\n",
-    "    json.dump({}, outfile, indent=4)"
+    "    json.dump({\n",
+    "        'read_from_cache': True,\n",
+    "        'write_to_cache': True\n",
+    "    }, outfile, indent=4)"
    ]
   },
   {
@@ -336,9 +347,9 @@
  "metadata": {
   "environment": {
    "kernel": "python3",
-   "name": "r-cpu.4-2.m104",
+   "name": "r-cpu.4-2.m108",
    "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/r-cpu.4-2:m104"
+   "uri": "gcr.io/deeplearning-platform-release/r-cpu.4-2:m108"
   },
   "kernelspec": {
    "display_name": "Python 3",

--- a/cromwell_setup/gvs_wdls/GvsImportGenomes.wdl
+++ b/cromwell_setup/gvs_wdls/GvsImportGenomes.wdl
@@ -29,6 +29,7 @@ workflow GvsImportGenomes {
     Int? load_data_preemptible_override
     Int? load_data_maxretries_override
     File? load_data_gatk_override
+    Int max_sleep_minutes
   }
 
   Int num_samples = length(external_sample_names)
@@ -123,7 +124,8 @@ workflow GvsImportGenomes {
         load_data_preemptible = effective_load_data_preemptible,
         load_data_maxretries = effective_load_data_maxretries,
         sample_names = read_lines(CreateFOFNs.vcf_sample_name_fofns[i]),
-        sample_map = GetUningestedSampleIds.sample_map
+        sample_map = GetUningestedSampleIds.sample_map,
+        max_sleep_minutes = max_sleep_minutes
     }
   }
 
@@ -193,6 +195,7 @@ task LoadData {
     File? gatk_override
     Int load_data_preemptible
     Int load_data_maxretries
+    Int max_sleep_minutes
   }
 
   Boolean load_ref_ranges = true
@@ -225,6 +228,11 @@ task LoadData {
     VCFS_ARRAY=(~{sep=" " input_vcfs})
     VCF_INDEXES_ARRAY=(~{sep=" " input_vcf_indexes})
     SAMPLE_NAMES_ARRAY=(~{sep=" " sample_names})
+    
+     # Sleep between 0-max minutes (chosen randomly)
+     SLEEP_TIME=$(( $RANDOM % ${max_sleep_minutes} ))
+     echo "Sleeping for ${SLEEP_TIME} minutes"
+     sleep "${SLEEP_TIME}m"
 
     # loop over the BASH arrays (See https://stackoverflow.com/questions/6723426/looping-over-arrays-printing-both-index-and-value)
     for i in "${!VCFS_ARRAY[@]}"; do

--- a/cromwell_setup/gvs_wdls/GvsJointVariantCalling.wdl
+++ b/cromwell_setup/gvs_wdls/GvsJointVariantCalling.wdl
@@ -12,6 +12,11 @@ workflow GvsJointVariantCalling {
         String call_set_identifier
         String? extract_output_gcs_dir
         String drop_state = "FORTY"
+        Boolean is_beta_user = true
+        Int load_data_batch_size = 20000
+        Int max_sleep_minutes = 1
+        Int? INDEL_VQSR_mem_gb_override
+        Int? SNP_VQSR_mem_gb_override
     }
 
     # the call_set_identifier string is used to name many different things throughout this workflow (BQ tables, vcfs etc),
@@ -23,7 +28,6 @@ workflow GvsJointVariantCalling {
       Int extract_maxretries_override = ""
       Int extract_preemptible_override = ""
       Int extract_scatter_count = ""
-      Int load_data_batch_size = ""
       Int load_data_preemptible_override = ""
       Int load_data_maxretries_override = ""
       Array[String] query_labels = []
@@ -31,9 +35,7 @@ workflow GvsJointVariantCalling {
       Int split_intervals_disk_size_override = ""
       Int split_intervals_mem_override = ""
       Int INDEL_VQSR_max_gaussians_override = 4
-      Int INDEL_VQSR_mem_gb_override = ""
       Int SNP_VQSR_max_gaussians_override = 6
-      Int SNP_VQSR_mem_gb_override = ""
     }
     # This is the most updated snapshot of the code as of Feb 10, 2023
     File gatk_override = "gs://gvs_quickstart_storage/jars/20230210/gatk-package-4.2.0.0-648-g69ad63b-SNAPSHOT-local.jar"
@@ -41,9 +43,6 @@ workflow GvsJointVariantCalling {
     Array[String] indel_recalibration_annotation_values = ["AS_FS", "AS_ReadPosRankSum", "AS_MQRankSum", "AS_QD", "AS_SOR"]
     Array[String] snp_recalibration_annotation_values = ["AS_QD", "AS_MQRankSum", "AS_ReadPosRankSum", "AS_FS", "AS_MQ", "AS_SOR"]
     File interval_weights_bed = "gs://broad-public-datasets/gvs/weights/gvs_vet_weights_1kb.bed"
-    # do we ever want non-beta customers to use this instead of using GvsUnified directly?  If so, we can make this an
-    # argument that just defaults to true
-    Boolean is_beta_user = true
 
     call GvsUnified.GvsUnified {
         input:
@@ -83,6 +82,7 @@ workflow GvsJointVariantCalling {
             SNP_VQSR_mem_gb_override = SNP_VQSR_mem_gb_override,
             drop_state = drop_state,
             is_beta_user = is_beta_user,
+            max_sleep_minutes=max_sleep_minutes
     }
 
     output {

--- a/cromwell_setup/gvs_wdls/GvsUnified.wdl
+++ b/cromwell_setup/gvs_wdls/GvsUnified.wdl
@@ -35,6 +35,7 @@ workflow GvsUnified {
         Int? load_data_batch_size
         Int? load_data_preemptible_override
         Int? load_data_maxretries_override
+        Int max_sleep_minutes
         # End GvsImportGenomes
 
         # Begin GvsCreateFilterSet
@@ -98,7 +99,8 @@ workflow GvsUnified {
             load_data_gatk_override = gatk_override,
             load_data_batch_size = load_data_batch_size,
             drop_state = drop_state,
-            is_rate_limited_beta_customer = is_beta_user
+            is_rate_limited_beta_customer = is_beta_user,
+            max_sleep_minutes = max_sleep_minutes
     }
 
     call PopulateAltAllele.GvsPopulateAltAllele {

--- a/cromwell_setup/gvs_wdls/GvsWarpTasks.wdl
+++ b/cromwell_setup/gvs_wdls/GvsWarpTasks.wdl
@@ -64,7 +64,7 @@ task SNPsVariantRecalibratorCreateModel {
         cpu: "2"
         bootDiskSizeGb: 15
         disks: "local-disk " + disk_size + " HDD"
-        preemptible: 1
+        preemptible: 0
         docker: "us.gcr.io/broad-gatk/gatk:4.1.9.0"
     }
 
@@ -132,7 +132,7 @@ task GatherTranches {
         cpu: "2"
         bootDiskSizeGb: 15
         disks: "local-disk " + disk_size + " HDD"
-        preemptible: 1
+        preemptible: 0
         docker: "us.gcr.io/broad-dsde-methods/broad-gatk-snapshots:varstore_d8a72b825eab2d979c8877448c0ca948fd9b34c7_change_to_hwe"
     }
 
@@ -198,7 +198,7 @@ task IndelsVariantRecalibrator {
         memory: "~{machine_mem} GiB"
         cpu: "2"
         disks: "local-disk " + disk_size + " HDD"
-        preemptible: 1
+        preemptible: 0
         docker: "us.gcr.io/broad-gatk/gatk:4.1.9.0"
     }
 


### PR DESCRIPTION
Changes to notebooks:
- Allows inputs to be configured for `is_beta_user`, `load_data_batch_size`, `max_sleep_minutes`, `INDEL_VQSR_mem_gb_override`, and `SNP_VQSR_mem_gb_override`.
- Sets read/write from/to call_cache to be true.

Changes to wdls:
- Adds random sleep time to `LoadData` task
- Removes preemptible attempts from tasks in `WarpTasks`