### PR TITLE
Clean up references to Terra

### DIFF
--- a/nextflow/README.md
+++ b/nextflow/README.md
@@ -1,9 +1,9 @@
-# Nextflow on Enterprise Terra
+# Nextflow on Verily Workbench
 
-This example shows how to get started with [Nextflow](https://www.nextflow.io) on Enterprise Terra.
+This example shows how to get started with [Nextflow](https://www.nextflow.io) on Verily Workbench.
 
 - The [nextflow_examples.ipynb](./nextflow_examples.ipynb) notebook shows 
-    - how to configure Nextflow for in your Terra cloud environment
+    - how to configure Nextflow for in your Verily Workbench cloud environment
     - how to install and run pipelines from [nf-core](https://nf-co.re/rnaseq) workflows, and 
     - how to leverage the [Google Life Sciences API](https://cloud.google.com/life-sciences/docs/concepts/introduction) as the workflow process executor.
 - Notebook snapshots are available if you'd like to preview the content of this notebook. To view a notebook snapshot, navigate to the "Notebook snapshots" folder in the Resources panel of this workspace. Then select a file and click the "Preview" button.

--- a/nextflow/nextflow_examples.ipynb
+++ b/nextflow/nextflow_examples.ipynb
@@ -1,14 +1,13 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "75b832f5-b010-4dc6-92f9-d7217b44a5d7",
    "metadata": {
     "tags": []
    },
    "source": [
-    "# Nextflow in Terra\n",
+    "# Nextflow on Verily Workbench\n",
     "<table align=\"left\">\n",
     "<td>\n",
     "<a href=\"https://github.com/DataBiosphere/terra-axon-examples/blob/main/nextflow/nextflow_examples.ipynb\">\n",
@@ -19,14 +18,13 @@
     "<td>\n",
     "<a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://github.com/DataBiosphere/terra-axon-examples/blob/main/nextflow/nextflow_examples.ipynb\">\n",
     "<img src=\"https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksK_vgx40SHs7jCqkTkCk=e14-rj-sc0xffffff-h130-w32\" alt=\"Vertex AI logo\">\n",
-    "Open in a Terra notebook instance\n",
+    "Open in a Verily Workbench notebook instance\n",
     "</a>\n",
     "</td>\n",
     "</table>"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "7d3e1fba",
    "metadata": {
@@ -37,7 +35,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "61d34c2a",
    "metadata": {
@@ -52,7 +49,7 @@
     "\n",
     "### Objectives\n",
     "\n",
-    "This notebook is intended to demonstrate how you can use the Nextflow engine on Terra to execute and manage workflows. By running the cells in this notebook, you will be able to:\n",
+    "This notebook is intended to demonstrate how you can use the Nextflow engine on Verily Workbench to execute and manage workflows. By running the cells in this notebook, you will be able to:\n",
     "* Configure Nextflow to run on this cloud environment\n",
     "* Run Nextflow workflows on actual datasets\n",
     "* Check the status of submitted jobs\n",
@@ -64,53 +61,39 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "50dd37b1",
    "metadata": {
     "tags": []
    },
    "source": [
-    "### Notebook setup <a id=\"workspace_setup\"> \n",
-    "<div class=\"alert alert-block alert-info\">\n",
-    "<b>Note:</b> This notebook assumes that you have run <a href=\"../workspace_setup.ipynb\">workspace_setup.ipynb</a> in the parent directory to create necessary workspace resources. Please note that you can skip creating a BigQuery dataset as that won't be used in this notebook's examples.\n",
-    "</div>\n",
-    "     Running the `workspace_setup.ipynb` notebook will create two Cloud Storage buckets for your workspace files with workspace reference names: \n",
-    "\n",
-    " - ws_files   \n",
-    " - ws_files_autodelete_after_two_weeks      \n",
-    "    \n",
-    "The code in this notebook will write output files to the \"autodelete\" bucket by default. Any file in this bucket will be automatically deleted two weeks after it is written. This alleviates the need for you to remember to clean up temporary and example files manually. If you want to write outputs to a durable location, simply change the assignment of the `BUCKET_REFERENCE` variable in the cell below and re-run the notebook. "
+    "## Notebook setup <a id=\"workspace_setup\"> "
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9f48ea42",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "# Change this to \"ws_files\" to use the durable workspace bucket instead of the autodelete bucket.\n",
-    "BUCKET_REFERENCE = \"ws_files_autodelete_after_two_weeks\"\n",
-    "\n",
-    "!terra resource resolve --name $BUCKET_REFERENCE || echo \"Be sure to run workspace_setup.ipynb before this notebook.\""
-   ]
-  },
-  {
-   "attachments": {},
    "cell_type": "markdown",
-   "id": "df46666b-f7dc-4595-95f8-4a0f153b0213",
+   "id": "2e00a5dc-e427-4d3f-9787-6e22baa6a9ca",
+   "metadata": {},
+   "source": [
+    "### Notebook dependencies\n",
+    "\n",
+    "Nextflow is installed by default in Verily Workbench workspaces, including this one. To test that it has been installed, you can run `nextflow -v`, which will output the installed version.\n",
+    "\n",
+    "For the provided examples to run successfully, you first need to run the cells in this section, which install the 'nf-core' tool, restart the kernel, and initialize variables that are utilized in one or both of the examples."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a85c59ce-13ef-499f-aa5f-8245accb0d57",
    "metadata": {
     "tags": []
    },
    "source": [
     "### Install `nf-core` tool\n",
     "\n",
-    "In order to interact with `nf-core` pipelines in this notebook,  you'll need to install the [`nf-core` companion tool](https://nf-co.re/tools), a command-line interface.\n",
+    "In order to interact with [`nf-core`](https://nf-co.re) pipelines in Example 2,  you'll need to install the [`nf-core` companion tool](https://nf-co.re/tools), a command-line interface.\n",
     "\n",
-    "1. Run the first cell below to install the tool in your Terra cloud environment. \n",
+    "1. Run the first cell below to install the tool in your cloud environment. \n",
     "2. Once installation has completed, navigate to the **Kernel** dropdown in the JupyterLab menu and select **Restart Kernel**. \n",
     "3. Once the kernel has restarted, run the second cell below to import the tool."
    ]
@@ -149,7 +132,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "c95e5cd7-77c0-4214-bf82-8bf672b007ea",
    "metadata": {
@@ -158,11 +140,10 @@
    "source": [
     "### Environment variables\n",
     "\n",
-    "One advantage of running your workflows in Terra is the ability to inject parameters into your commands from the workspace context. You can pass parameter values such as your Google Cloud Storage bucket's URL or your service account's email address with convenient, readable names in CLI commands, preventing you the tedious and error-prone copying and pasting of values otherwise required. (To view this workspace's environment variables and their corresponding values, you can run the command `terra app execute env | sort`.)"
+    "One advantage of running your workflows in Verily Workbench is the ability to inject parameters into your commands from the workspace context. You can pass parameter values such as your Google Cloud Storage bucket's URL or your service account's email address with convenient, readable names in CLI commands, preventing you the tedious and error-prone copying and pasting of values otherwise required. (To view this workspace's environment variables and their corresponding values, you can run the command `terra app execute env | sort`.)"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "5babf59d",
    "metadata": {
@@ -171,7 +152,7 @@
    "source": [
     "### Check environment variables\n",
     "\n",
-    "Upon running this notebook in a fresh cloud environment, you may discover that your environment variables are not available on your workspace context. Please run the cell below to check these variables. If the exception is raised, you should restart this cloud environment in the Terra UI."
+    "Upon running this notebook in a fresh cloud environment, you may discover that your environment variables are not available on your workspace context. Please run the cell below to check these variables. If the exception is raised, you should restart this cloud environment in the Verily Workbench UI."
    ]
   },
   {
@@ -196,13 +177,11 @@
     "            and os.getenv('GOOGLE_SERVICE_ACCOUNT_EMAIL')\n",
     "            and os.getenv('TERRA_USER_EMAIL')) :\n",
     "        raise Exception('Restart your TVC Cloud Environment so that the TVC environment variables become available.')       \n",
-    "    else:\n",
-    "        print(\"Environment variables available as expected.\")\n",
+    "\n",
     "check_environment_variables()"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "2f6088b1-8a81-4671-a6af-b7f48d982a69",
    "metadata": {},
@@ -228,19 +207,39 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "id": "7be45251-315e-4134-a215-2891d0f21a1e",
-   "metadata": {
-    "tags": []
-   },
+   "id": "f663c17b-3e61-4410-b65d-89ecded638d8",
+   "metadata": {},
    "source": [
-    "### Do I need to install `Nextflow` or other dependencies in my Terra workspace?\n",
-    "By default, Nextflow is installed in Terra workspaces, so you don't need to install anything to complete the exercises in this notebook."
+    "### Workspace setup notebook\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<b>Note:</b> This notebook assumes that you have run <a href=\"../workspace_setup.ipynb\">workspace_setup.ipynb</a> in the parent directory to create necessary workspace resources. Please note that you can skip creating a BigQuery dataset as that won't be used in this notebook's examples.\n",
+    "</div>\n",
+    "     Running the `workspace_setup.ipynb` notebook will create two Cloud Storage buckets for your workspace files with workspace reference names: \n",
+    "\n",
+    " - ws_files   \n",
+    " - ws_files_autodelete_after_two_weeks      \n",
+    "    \n",
+    "The code in this notebook will write output files to the \"autodelete\" bucket by default. Any file in this bucket will be automatically deleted two weeks after it is written. This alleviates the need for you to remember to clean up temporary and example files manually. If you want to write outputs to a durable location, simply change the assignment of the `BUCKET_REFERENCE` variable in the cell below and re-run the notebook. "
    ]
   },
   {
-   "attachments": {},
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9f48ea42",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Change this to \"ws_files\" to use the durable workspace bucket instead of the autodelete bucket.\n",
+    "BUCKET_REFERENCE = \"ws_files_autodelete_after_two_weeks\"\n",
+    "\n",
+    "!terra resource resolve --name $BUCKET_REFERENCE || echo \"Be sure to run workspace_setup.ipynb before this notebook.\""
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "b0c1fd90-1500-4154-bf5e-f790da32e296",
    "metadata": {
@@ -255,7 +254,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "eb9bd29c-cf25-4973-b621-d4ec9dd98d3b",
    "metadata": {
@@ -266,11 +264,11 @@
     "\n",
     "<div class=\"alert alert-block alert-success\">\n",
     "<b>Note:</b> \n",
-    "To access private GitHub repositories from your Terra workspace, you'll need to <a href=\"https://et-docs-tests.googleplex.com/docs/how_to_guides/terra_ssh_key_guide/#set-up-your-tvc-ssh-key-with-github\">set up an SSH key</a> to connect your GitHub and Terra accounts. This is not necessary for the exercises in this notebook because the repositories you will need are publicly available.\n",
-    "*NOTE* Until <a href=\"https://verily.atlassian.net/browse/TERRA-358?atlOrigin=eyJpIjoiYWQ2YTNlYWQ5OWVhNDM2Zjk1OTYxMGQ4YzdkMzJjN2UiLCJwIjoiaiJ9\"> the Workflows Notebooks are migrated to a public repository</a>, you actually DO need to have your Terra SSH key set up to run the exercises in this notebook.\n",
+    "To access private GitHub repositories from your Verily Workbench workspace, you'll need to <a href=\"https://et-docs-tests.googleplex.com/docs/how_to_guides/terra_ssh_key_guide/#set-up-your-tvc-ssh-key-with-github\">set up an SSH key</a> to connect your GitHub and Verily Workbench accounts. This is not necessary for the exercises in this notebook because the repositories you will need are publicly available.\n",
+    "*NOTE* Until <a href=\"https://verily.atlassian.net/browse/TERRA-358?atlOrigin=eyJpIjoiYWQ2YTNlYWQ5OWVhNDM2Zjk1OTYxMGQ4YzdkMzJjN2UiLCJwIjoiaiJ9\"> the Workflows Notebooks are migrated to a public repository</a>, you actually DO need to have your Verily Workbench SSH key set up to run the exercises in this notebook.\n",
     "</div>\n",
     "\n",
-    "Terra features built-in support for source control via [GitHub](https://github.com). Users who have set up the Terra SSH key can run `terra git` commands from their Terra workspaces without additional authentication.\n",
+    "Verily Workbench features built-in support for source control via [GitHub](https://github.com). Users who have set up the Verily Workbench SSH key can run `terra git` commands from their Verily Workbench workspaces without additional authentication.\n",
     "\n",
     "In this exercise, you will use files from a public [GitHub repository](https://github.com/nextflow-io/rnaseq-nf.git) which contains a basic pipeline for quantification of genomic features from short read data and some data upon which to run the workflow.\n",
     "\n",
@@ -295,11 +293,10 @@
     "    --name=rnaseq-nf \\\n",
     "    --description=\"Respository containing a Nextflow RNASeq pipeline and associated input data.\" \\\n",
     "    --repo-url='https://github.com/nextflow-io/rnaseq-nf.git')\n",
-    "!cd /home/jupyter/repos && terra git clone --resource=rnaseq-nf"
+    "!cd /home/jupyter && terra git clone --resource=rnaseq-nf"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "8c862cd8",
    "metadata": {
@@ -310,7 +307,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "94ae2043-4642-4773-bab4-1b00ffb76164",
    "metadata": {
@@ -326,7 +322,7 @@
     "* `$GOOGLE_CLOUD_PROJECT` and \n",
     "* `$GOOGLE_SERVICE_ACCOUNT_EMAIL`. \n",
     "\n",
-    "If you've created the workspace bucket resource after you created this notebook instance (either via the [Terra workspace UI](f'https://terra-devel-ui-terra.api.verily.com/workspaces/emmarogge-workflows-ws) or Terra CLI commands, your bucket reference may not resolve correctly due to a stale workspace context cache (see [bug](https://broadworkbench.atlassian.net/browse/PF-2302)). To resolve the variable, you'll need to run `terra resource list` to refresh the cached workspace context, then re-run the cell below.\n",
+    "If you've created the workspace bucket resource after you created this notebook instance (either via the [Verily Workbench workspace UI](f'https://terra-devel-ui-terra.api.verily.com/workspaces/emmarogge-workflows-ws) or Terra CLI commands, your bucket reference may not resolve correctly due to a stale workspace context cache (see [bug](https://broadworkbench.atlassian.net/browse/PF-2302)). To resolve the variable, you'll need to run `terra resource list` to refresh the cached workspace context, then re-run the cell below.\n",
     "\n",
     "Please note that `google.region` specifies the [Google location(s)](https://cloud.google.com/life-sciences/docs/concepts/locations) where the job executions are deployed to the Cloud Life Sciences API, whereas `google.location` specifies the [Google region(s)](https://cloud.google.com/compute/docs/regions-zones/) where the computation is executed on Compute Engine VMs."
    ]
@@ -362,27 +358,26 @@
     "        google.lifeSciences.serviceAccountEmail = \"$GOOGLE_SERVICE_ACCOUNT_EMAIL\"\n",
     "        }}\"\"\"\n",
     "    \n",
-    "    # Replace boilerplate with Terra-specific config for Google Lifesciences APIs.\n",
+    "    # Replace boilerplate with V-specific config for Google Lifesciences APIs.\n",
     "    regex = \"(?s)gls(\\s\\{.*?\\s\\})(?=\\s|$)\"\n",
-    "    config_file = open(\"/home/jupyter/repos/rnaseq-nf/nextflow.config\", \"r\")\n",
+    "    config_file = open(\"/home/jupyter/rnaseq-nf/nextflow.config\", \"r\")\n",
     "    data = config_file.read()\n",
     "    config_file.close()\n",
     "    result = re.sub(regex, terra_gls_config, data, 1)\n",
     "\n",
     "    if result:\n",
-    "        config_file = open(\"/home/jupyter/repos/rnaseq-nf/nextflow.config\", \"w\")\n",
+    "        config_file = open(\"/home/jupyter/rnaseq-nf/nextflow.config\", \"w\")\n",
     "        config_file.write(result)\n",
     "        config_file.close()\n",
     "\n",
     "# Copy existing configuration file before we modify it.\n",
-    "!cp /home/jupyter/repos/rnaseq-nf/nextflow.config /home/jupyter/repos/rnaseq-nf/unmodified_nextflow.config\n",
+    "!cp /home/jupyter/rnaseq-nf/nextflow.config /home/jupyter/rnaseq-nf/unmodified_nextflow.config\n",
     "\n",
     "# Inject configuration.\n",
     "configure_nextflow_for_terra()"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "bdbb6e0a-5499-4c5e-8ae7-314fab8735f6",
    "metadata": {
@@ -440,11 +435,10 @@
    },
    "outputs": [],
    "source": [
-    "!terra nextflow -c /home/jupyter/repos/rnaseq-nf/nextflow.config config /home/jupyter/repos/rnaseq-nf/main.nf -profile gls"
+    "!terra nextflow -c /home/jupyter/rnaseq-nf/nextflow.config config /home/jupyter/rnaseq-nf/main.nf -profile gls"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "53754012-4fdf-47f1-b3c3-25b20a8f3cec",
    "metadata": {
@@ -475,11 +469,10 @@
    },
    "outputs": [],
    "source": [
-    "!terra nextflow -c /home/jupyter/repos/rnaseq-nf/nextflow.config run /home/jupyter/rnaseq-nf/main.nf -profile gls"
+    "!terra nextflow -c /home/jupyter/rnaseq-nf/nextflow.config run /home/jupyter/rnaseq-nf/main.nf -profile gls"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "2d7aa5df-24a6-478b-94f2-d32417ce1741",
    "metadata": {},
@@ -506,7 +499,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "b438dc0e-57d4-44b2-85a0-63c2ad4120a1",
    "metadata": {},
@@ -529,7 +521,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "79a61e5d-8cb4-421e-a8bb-ae97b0514905",
    "metadata": {
@@ -546,7 +537,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "a70a5f93-bd62-44aa-8616-48f6e64b16f9",
    "metadata": {},
@@ -573,7 +563,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "d1d54a69-3bd8-4127-a477-da64f64baf36",
    "metadata": {},
@@ -596,7 +585,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "6fbfec09-7790-4956-a807-08af4a250397",
    "metadata": {
@@ -605,13 +593,12 @@
    "source": [
     "## Example 2: Run an `nf-core` workflow\n",
     "\n",
-    "Nextflow's `nf-core` is a curated collection of validated Nextflow pipelines, most of which can be run on almost any computing environment, including your Terra cloud environment. These pipelines are subject to transparent versioning and each version is run against automated testing prior to release. In this exercise, we will perform RNASeq on by running the nf-core/RNASeq pipeline from the [`nf_core` collection](https://nf-co.re/pipelines). The cost of running this example will typically be no more than $1.\n",
+    "Nextflow's `nf-core` is a curated collection of validated Nextflow pipelines, most of which can be run on almost any computing environment, including your Verily Workbench cloud environment. These pipelines are subject to transparent versioning and each version is run against automated testing prior to release. In this exercise, we will perform RNASeq on by running the nf-core/RNASeq pipeline from the [`nf_core` collection](https://nf-co.re/pipelines). The cost of running this example will typically be no more than $1.\n",
     "\n",
     "If desired, you can preview a fully-executed version of this notebook section by viewing [this notebook snapshot](https://terra-preprod-ui-terra.api.verily.com/workspaces/getting-started-with-workflows-workspace/resources/eebc2df6-fc9d-491e-874c-b87dbd3a68e1/notebook_snapshots/nextflow_examples_second_exercise_fully_executed.html). "
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "5225b331-2bec-4cd7-ba57-5de4fdaf6526",
    "metadata": {},
@@ -635,7 +622,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "dba08a1b-aadf-44b1-a1e4-48bdd0b40f10",
    "metadata": {
@@ -650,7 +636,7 @@
     "* `$GOOGLE_CLOUD_PROJECT` and \n",
     "* `$GOOGLE_SERVICE_ACCOUNT_EMAIL`. \n",
     "\n",
-    "If you've created the workspace bucket resource after you created this notebook instance (either via the [Terra workspace UI](f'https://terra-devel-ui-terra.api.verily.com/workspaces/emmarogge-workflows-ws) or Terra CLI commands, your bucket reference may not resolve correctly due to a stale workspace context cache (see [bug](https://broadworkbench.atlassian.net/browse/PF-2302)). To resolve the variable, you'll need to run `terra resource list` to refresh the cached workspace context, then re-run the cell below.\n"
+    "If you've created the workspace bucket resource after you created this notebook instance (either via the [Verily Workbench workspace UI](f'https://terra-devel-ui-terra.api.verily.com/workspaces/emmarogge-workflows-ws) or Terra CLI commands, your bucket reference may not resolve correctly due to a stale workspace context cache (see [bug](https://broadworkbench.atlassian.net/browse/PF-2302)). To resolve the variable, you'll need to run `terra resource list` to refresh the cached workspace context, then re-run the cell below.\n"
    ]
   },
   {
@@ -708,14 +694,13 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "e2cda28f-c014-4bcd-b5c2-a16001f70b10",
    "metadata": {},
    "source": [
     "### View expanded configuration\n",
     "\n",
-    "Run the cell below to output the Nextflow configuration's fully-expanded values to the file `expanded_nf_core.config`, then print the parameters and their values (injected from the Terra workspace context and by the function above) to the console."
+    "Run the cell below to output the Nextflow configuration's fully-expanded values to the file `expanded_nf_core.config`, then print the parameters and their values (injected from the Verily Workbench workspace context and by the function above) to the console."
    ]
   },
   {
@@ -733,7 +718,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "c81deb92-c421-4f7e-932a-525b4988d641",
    "metadata": {},
@@ -742,7 +726,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "3141b4d6-c9d4-49f1-bd66-dfcfcbcc945d",
    "metadata": {},
@@ -758,7 +741,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "d5bc8401-120e-4bca-86bd-184a5ec3eb8e",
    "metadata": {},
@@ -775,12 +757,11 @@
    },
    "outputs": [],
    "source": [
-    "!cd /home/jupyter/repos/test-datasets && git checkout rnaseq\n",
-    "!cd /home/jupyter/repos/test-datasets && cat samplesheet/samplesheet_minimal.csv || echo \"Something's not quite right. Please ensure you've added the Git repo as referenced resource and checked out the RNASeq branch.\""
+    "!cd /home/jupyter/test-datasets && git checkout rnaseq\n",
+    "!cd /home/jupyter/test-datasets && cat samplesheet/samplesheet_minimal.csv || echo \"Something's not quite right. Please ensure you've added the Git repo as referenced resource and checked out the RNASeq branch.\""
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "7d872c44-451c-4e76-87b2-3ed6267822b5",
    "metadata": {},
@@ -797,11 +778,10 @@
    },
    "outputs": [],
    "source": [
-    "![[ -f repos/test-datasets/samplesheet/samplesheet_minimal.csv ]] && echo \"Resource already exists\" || (terra resource add-ref git-repo --name=test-datasets --repo-url=git@github.com:nf-core/test-datasets.git && cd /home/jupyter/repos && terra git clone --resource=nf-core-sample-data-repo &&  git checkout rnaseq)"
+    "![[ -f test-datasets/samplesheet/samplesheet_minimal.csv ]] && echo \"Resource already exists\" || (terra resource add-ref git-repo --name=test-datasets --repo-url=git@github.com:nf-core/test-datasets.git && cd /home/jupyter && terra git clone --resource=nf-core-sample-data-repo &&  git checkout rnaseq)"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "32a79377-dc63-49e0-a2d1-d03af407dc3e",
    "metadata": {
@@ -846,12 +826,11 @@
     "-w $(terra resource resolve \\\n",
     "--name=ws_files_autodelete_after_two_weeks)/nf_core/wd -r 3.11.1 \\\n",
     "--outdir $(terra resource resolve --name=ws_files_autodelete_after_two_weeks)/nf_core/output \\\n",
-    "--input /home/jupyter/repos/test-datasets/samplesheet/samplesheet_minimal.csv \\\n",
+    "--input /home/jupyter/test-datasets/samplesheet/samplesheet_minimal.csv \\\n",
     "--genome 'R64-1-1'"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "6a8577fc-1a34-4643-8823-65d6a4c2a1b4",
    "metadata": {},
@@ -878,7 +857,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "e8257646-3704-4d75-9af0-141bf5266a89",
    "metadata": {
@@ -912,12 +890,11 @@
     "!terra nextflow -c /home/jupyter/nextflow.config run nf-core/rnaseq -resume <SESSION_ID> -profile gls \\\n",
     "-w $(terra resource resolve --name=ws_files_autodelete_after_two_weeks)/nf_core/wd -r 3.11.1 \\\n",
     "--outdir $(terra resource resolve --name=ws_files_autodelete_after_two_weeks)/nf_core/output/resumed \\\n",
-    "--input /home/jupyter/repos/test-datasets/samplesheet/samplesheet_minimal.csv \\\n",
+    "--input /home/jupyter/test-datasets/samplesheet/samplesheet_minimal.csv \\\n",
     "--genome 'R64-1-1'"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "fb9b22bf-e591-4f69-8c3c-ebe364370136",
    "metadata": {},
@@ -939,7 +916,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "bef762a8-0b46-4e8b-8352-b46bb05a0d94",
    "metadata": {},
@@ -967,7 +943,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "f34fca73-b5b7-4920-b4f4-c733ffa743ba",
    "metadata": {},
@@ -994,7 +969,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "8f8b7859-4c96-45ef-bfcb-3947ed5a29ab",
    "metadata": {},
@@ -1015,7 +989,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "b4d3c885-b704-4341-9b6c-aa696fb125d3",
    "metadata": {
@@ -1038,7 +1011,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "ac579eb8-8c5f-441f-b0dc-3c435c88ee6b",
    "metadata": {},
@@ -1057,7 +1029,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "b8918feb-96d9-47fa-951e-9b32b01fec52",
    "metadata": {},
@@ -1076,7 +1047,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "b33864c2-4756-463c-b3a9-81652f0b1403",
    "metadata": {},
@@ -1095,7 +1065,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "9e574345-d7a1-400f-a56b-6013016cd6cb",
    "metadata": {},
@@ -1114,7 +1083,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "52f96eca-57b4-4aaa-becb-b20ee3c92ce6",
    "metadata": {},

--- a/nextflow/workspace_description.md
+++ b/nextflow/workspace_description.md
@@ -1,15 +1,15 @@
 # Overview
 
-This notebook shows how to get started with [Nextflow](https://www.nextflow.io) on Enterprise Terra.
+This notebook shows how to get started with [Nextflow](https://www.nextflow.io) on Verily Workbench.
 
 # How do I get started?
 
 ## Step 0: _Duplicate_ this workspace
 
-- *Duplicate* this workspace. You can do that via the 'three-dot' menu in the upper right of the workspace. Duplicating this workspace ensures three Git repositories required for these examples will be automatically cloned when you create a Cloud Environment.
+- *Duplicate* this workspace. You can do that via the 'three-dot' menu in the upper right of the workspace. Duplicating this workspace ensures three Git repositories required for these examples will be automatically cloned when you create a [cloud environment](https://terra-docs.api.verily.com/docs/reference/glossary/#cloud-environment).
 
    The required repositories which will be cloned include:
-  1. [`terra-axon-examples` example repo](https://github.com/DataBiosphere/terra-axon-examples): Contains JupyterLab notebook `nextflow_examples.ipynb` which demonstrates how to configure and run Nextflow workflows in Enterprise Terra.
+  1. [`terra-axon-examples` example repo](https://github.com/DataBiosphere/terra-axon-examples): Contains JupyterLab notebook `nextflow_examples.ipynb` which demonstrates how to configure and run Nextflow workflows in Verily Workbench.
   2. [`rnaseq-nf` repo](https://github.com/nextflow-io/rnaseq-nf): Contains a Nextflow RNASeq workflow specification and associated human genomic input data.
   3. [`test-datasets` repo](https://github.com/nf-core/test-datasets): For each workflow in the `nf-core` collection, this repo has a branch with appropriate, workflow-specific test data.
   > **Note**: If you do not have a GitHub account, then you can clone each repo manually after you've created the cloud environment.
@@ -19,7 +19,7 @@ This notebook shows how to get started with [Nextflow](https://www.nextflow.io) 
 
 To gain a better understanding of the setup and analysis included in this demonstration workspace, previews of this notebook that include cell outputs are provided. Navigate to your workspace's Resources tab, then select the "Notebook snapshots" folder. To view a notebook snapshot, select a file in said folder and click the "Preview" button.
 
-## Step 2: Create an Verily Workbench cloud environment and run a setup notebook.
+## Step 2: Create a Verily Workbench cloud environment and run a setup notebook.
 
 Create an Verily Workbench [cloud environment](https://terra-docs.api.verily.com/docs/reference/glossary/#cloud-environment) by navigating to the "Environments" tab of the workspace. You can use the configuration defaults.
 

--- a/nextflow/workspace_description.md
+++ b/nextflow/workspace_description.md
@@ -12,18 +12,18 @@ This notebook shows how to get started with [Nextflow](https://www.nextflow.io) 
   1. [`terra-axon-examples` example repo](https://github.com/DataBiosphere/terra-axon-examples): Contains JupyterLab notebook `nextflow_examples.ipynb` which demonstrates how to configure and run Nextflow workflows in Enterprise Terra.
   2. [`rnaseq-nf` repo](https://github.com/nextflow-io/rnaseq-nf): Contains a Nextflow RNASeq workflow specification and associated human genomic input data.
   3. [`test-datasets` repo](https://github.com/nf-core/test-datasets): For each workflow in the `nf-core` collection, this repo has a branch with appropriate, workflow-specific test data.
-  > **Note**: If you do not have a GitHub account, then you can clone each repo manually after you've created the Cloud Environment.
+  > **Note**: If you do not have a GitHub account, then you can clone each repo manually after you've created the cloud environment.
 
 
 ## Step 1: Preview prior runs of the relevant notebooks.
 
 To gain a better understanding of the setup and analysis included in this demonstration workspace, previews of this notebook that include cell outputs are provided. Navigate to your workspace's Resources tab, then select the "Notebook snapshots" folder. To view a notebook snapshot, select a file in said folder and click the "Preview" button.
 
-## Step 2: Create an Enterprise Terra Cloud Environment and run a setup notebook.
+## Step 2: Create an Verily Workbench cloud environment and run a setup notebook.
 
-Create an Enterprise Terra Cloud environment, by navigating to the "Environments" tab of the workspace. You can use the configuration defaults.
+Create an Verily Workbench [cloud environment](https://terra-docs.api.verily.com/docs/reference/glossary/#cloud-environment) by navigating to the "Environments" tab of the workspace. You can use the configuration defaults.
 
-Launch the environment once it's running, and then run the notebook [workspace_setup.ipynb](https://github.com/DataBiosphere/terra-axon-examples/blob/main/workspace_setup.ipynb). Its repo, `terra-axon-examples`, which is defined as a workspace Git repository, should be automatically cloned to your Enterprise Terra Cloud Environment, and you should be able to navigate to the notebook in the JupyterLab file browser. Look for the `terra-axon-examples` subdirectory.
+Launch the environment once it's running, and then run the notebook [workspace_setup.ipynb](https://github.com/DataBiosphere/terra-axon-examples/blob/main/workspace_setup.ipynb). Its repo, `terra-axon-examples`, which is defined as a workspace Git repository, should be automatically cloned to your Verily Workbench cloud environment, and you should be able to navigate to the notebook in the JupyterLab file browser. Look for the `terra-axon-examples` subdirectory.
 
 **If you do not see the `terra-axon-examples` subdirectory**, open a Terminal window on the notebook server (under the **File** menu) and run:
 >  ```sh
@@ -31,7 +31,7 @@ Launch the environment once it's running, and then run the notebook [workspace_s
 
 ## Step 3: Run the Nextflow examples.
 
-Two examples are provided in `nextflow_examples.ipynb`. You will find this notebook in [the `nextflow` directory of the `terra-axon-examples` repository](https://github.com/https://github.com/DataBiosphere/terra-axon-examples/tree/main/nextflow).  As mentioned above, its repo, `terra-axon-examples`, will be automatically cloned to your Enterprise Terra Cloud Environment, and you should be able to navigate to the notebook in the JupyterLab file browser. Before running either example, you'll need to run the Setup section.
+Two examples are provided in `nextflow_examples.ipynb`. You will find this notebook in [the `nextflow` directory of the `terra-axon-examples` repository](https://github.com/https://github.com/DataBiosphere/terra-axon-examples/tree/main/nextflow).  As mentioned above, its repo, `terra-axon-examples`, will be automatically cloned to your Verily Workbench cloud environment, and you should be able to navigate to the notebook in the JupyterLab file browser. Before running either example, you'll need to run the Setup section.
 
 - The first example demonstrates running a Nextflow RNASeq workflow on human gut data.
 - The second example demonstrates running the [`nf-core`](https://nf-co.re/) RNASeq pipeline on yeast genome data.
@@ -44,4 +44,4 @@ Running each example will result in the creation of a MultiQC report.
 
 To preview what reports can be expected to look like, navigate to your workspace's Resources tab, then select the "Report previews" folder. To view a report, select a file in said folder and click the "Preview" button.
 
-Please note that a warning about Javascript being disabled is expected; instructions in the notebook are provided to address this for the actual reports you produce.
+Please note that a warning about Javascript being disabled is expected; instructions are provided in the notebook to address this for the actual reports you produce.


### PR DESCRIPTION
Replace all references to "Enterprise Terra" with "Verily Workbench" in notebook, README and workspace description.