### PR TITLE
BENCH-640: Guide users to reset workspace to original

### DIFF
--- a/first_hour_on_vwb/working_with_data_collections.ipynb
+++ b/first_hour_on_vwb/working_with_data_collections.ipynb
@@ -225,7 +225,24 @@
    "source": [
     "### Add resources to data collection\n",
     "\n",
-    "Add new controlled and/or referenced resources to the workspace created in the previous step using the Terra CLI or the Verily Workbench Resources tab. To easily add resources, use the widgets provided in [../workspace_resource_examples.ipynb](../workspace_resource_examples.ipynb../workspace_resource_examples.ipynb)."
+    "Add new controlled and/or referenced resources to the workspace created in the previous step using the Terra CLI or the Verily Workbench Resources tab. To easily add resources, use the widgets provided in [../workspace_resource_examples.ipynb](../workspace_resource_examples.ipynb../workspace_resource_examples.ipynb).\n",
+    "\n",
+    "### Reset your current workspace ID\n",
+    "\n",
+    "When you create a new workspace via the Verily Workbench CLI, your cloud environment will automatically point to that newly-created workspace as your current workspace. This behavior means you can jump right into adding resources once you've created a new workspace without having to point the cloud environment to the new workspace explicitly. However, since you will next convert your newly created workspace into a data collection, you should ensure that you point your cloud environment back to your original, non-data-collection workspace before proceeding further in this notebook.\n",
+    "\n",
+    "Run the cell below to point your cloud environment to the original workspace as your current workspace."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "!terra workspace set --id={CURRENT_WORKSPACE_ID}"
    ]
   },
   {


### PR DESCRIPTION
Instruct users, once they have created a new workspace, to reset their cloud environment to point to the original workspace as the current workspace. Provide explanation in Markdown and a cell to run the CLI command to reset to the current workspace ID.