### PR TITLE
Replace command to create BigQuery table reference

### DIFF
--- a/first_hour_on_vwb/working_with_resources.ipynb
+++ b/first_hour_on_vwb/working_with_resources.ipynb
@@ -391,6 +391,7 @@
     "            print('\\n'.join(commandList))\n",
     "            print('')\n",
     "            \n",
+    "            result = subprocess.run(commandList, capture_output = True, text = True)\n",
     "            print(result.stderr) if not result.stdout else print(result.stdout)\n",
     "\n",
     "\n",


### PR DESCRIPTION
This is a one-line change to replace a line that was accidentally removed in previous refactoring PR. This line actually runs the CLI command to create a referenced BigQuery table resource.