### PR TITLE
Remove links to open in VertexAI

### DIFF
--- a/first_hour_on_vwb/working_with_data_collections.ipynb
+++ b/first_hour_on_vwb/working_with_data_collections.ipynb
@@ -14,12 +14,6 @@
     "      View on GitHub\n",
     "    </a>\n",
     "  </td>\n",
-    "  <td>\n",
-    "    <a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://github.com/DataBiosphere/terra-axon-examples/main/first_hour_on_vwb/working_with_data_collections.ipynb\">\n",
-    "      <img src=\"https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksK_vgx40SHs7jCqkTkCk=e14-rj-sc0xffffff-h130-w32\" alt=\"Vertex AI logo\">\n",
-    "      Open in a Verily Workbench cloud environment\n",
-    "    </a>\n",
-    "  </td>                                                                                               \n",
     "</table>"
    ]
   },

--- a/first_hour_on_vwb/working_with_groups.ipynb
+++ b/first_hour_on_vwb/working_with_groups.ipynb
@@ -13,13 +13,7 @@
     "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
     "      View on GitHub\n",
     "    </a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://github.com/DataBiosphere/terra-axon-examples/main/first_hour_on_vwb/working_with_groups.ipynb\">\n",
-    "      <img src=\"https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksK_vgx40SHs7jCqkTkCk=e14-rj-sc0xffffff-h130-w32\" alt=\"Vertex AI logo\">\n",
-    "      Open in a Verily Workbench cloud environment\n",
-    "    </a>\n",
-    "  </td>                                                                                               \n",
+    "  </td>                                                                                             \n",
     "</table>"
    ]
   },

--- a/first_hour_on_vwb/working_with_resources.ipynb
+++ b/first_hour_on_vwb/working_with_resources.ipynb
@@ -13,13 +13,7 @@
     "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
     "      View on GitHub\n",
     "    </a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://github.com/DataBiosphere/terra-axon-examples/main/first_hour_on_vwb/working_with_resources.ipynb\">\n",
-    "      <img src=\"https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksK_vgx40SHs7jCqkTkCk=e14-rj-sc0xffffff-h130-w32\" alt=\"Vertex AI logo\">\n",
-    "      Open in a Verily Workbench cloud environment\n",
-    "    </a>\n",
-    "  </td>                                                                                               \n",
+    "  </td>                                                                                             \n",
     "</table>\n"
    ]
   },


### PR DESCRIPTION
As the notebooks rely on a shared Python utility module, which is not provided when the notebooks are opened via the link to 'open in VertexAI', remove links from headers of notebooks.