### PR TITLE
Add example notebooks for querying public CMS SynPuf OMOP dataset

### DIFF
--- a/omop_examples/extract_drug_treatments_from_a_molecule.ipynb
+++ b/omop_examples/extract_drug_treatments_from_a_molecule.ipynb
@@ -51,12 +51,12 @@
    "outputs": [],
    "source": [
     "'''\n",
-    "Resolves bucket URL from bucket reference in workspace.\n",
+    "Resolves BQ dataset from reference in workspace.\n",
     "'''\n",
-    "def get_bucket_url_from_reference(bucket_reference):\n",
-    "    BUCKET_CMD_OUTPUT = !terra resolve --name={bucket_reference}\n",
-    "    BUCKET = BUCKET_CMD_OUTPUT[0]\n",
-    "    return BUCKET\n",
+    "def get_bq_dataset_from_reference(resource_name):\n",
+    "    BQ_CMD_OUTPUT = !terra resolve --name={resource_name}\n",
+    "    BQ_DATASET = BQ_CMD_OUTPUT[0]\n",
+    "    return BQ_DATASET\n",
     "\n",
     "'''\n",
     "Resolves current workspace ID from workspace description.\n",
@@ -85,7 +85,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "BQ_dataset = 'bigquery-public-data.cms_synthetic_patient_data_omop'\n",
+    "BQ_dataset = get_bq_dataset_from_reference('cms_synthetic_patient_data_omop')\n",
     "\n",
     "job_query_config = bigquery.QueryJobConfig(default_dataset=BQ_dataset)\n",
     "client = bigquery.Client(default_query_job_config=job_query_config)"

--- a/omop_examples/extract_drug_treatments_from_a_molecule.ipynb
+++ b/omop_examples/extract_drug_treatments_from_a_molecule.ipynb
@@ -56,18 +56,7 @@
     "def get_bq_dataset_from_reference(resource_name):\n",
     "    BQ_CMD_OUTPUT = !terra resolve --name={resource_name}\n",
     "    BQ_DATASET = BQ_CMD_OUTPUT[0]\n",
-    "    return BQ_DATASET\n",
-    "\n",
-    "'''\n",
-    "Resolves current workspace ID from workspace description.\n",
-    "'''\n",
-    "def get_current_workspace_id():\n",
-    "    WORKSPACE_CMD_OUTPUT = !terra workspace describe --format=json | jq --raw-output \".id\"\n",
-    "    WORKSPACE_ID = WORKSPACE_CMD_OUTPUT[0]\n",
-    "    return WORKSPACE_ID\n",
-    "\n",
-    "CURRENT_WORKSPACE_ID = get_current_workspace_id()\n",
-    "print(f'Workspace ID: {CURRENT_WORKSPACE_ID}')"
+    "    return BQ_DATASET"
    ]
   },
   {

--- a/omop_examples/extract_drug_treatments_from_a_molecule.ipynb
+++ b/omop_examples/extract_drug_treatments_from_a_molecule.ipynb
@@ -1,0 +1,278 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d4753f46-ea81-471e-9cfb-fdab151e6267",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# CMS SynPuf: How to extract drug treatments containing a specific molecule\n",
+    "\n",
+    "This notebook queries the [CMS SynPuf dataset](https://console.cloud.google.com/marketplace/product/hhs/synpuf?pli=1), a public synthetic patient data in OMOP. This notebook is intended to be used as an example for how to query the public OMOP dataset, and how to do basic visualizations."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7f8336bd-793c-4cba-9217-0927e1b16f87",
+   "metadata": {},
+   "source": [
+    "## Import python libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "71671891-b357-4b3d-9af1-1b5a67a1f340",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from google.cloud import bigquery\n",
+    "\n",
+    "# Enable IPython to display matplotlib graphs.\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ab938992-40b0-4fee-976a-150665bb0903",
+   "metadata": {},
+   "source": [
+    "## Notebook setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3725ee38-87f0-408d-bb14-6a027ab7409f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "'''\n",
+    "Resolves bucket URL from bucket reference in workspace.\n",
+    "'''\n",
+    "def get_bucket_url_from_reference(bucket_reference):\n",
+    "    BUCKET_CMD_OUTPUT = !terra resolve --name={bucket_reference}\n",
+    "    BUCKET = BUCKET_CMD_OUTPUT[0]\n",
+    "    return BUCKET\n",
+    "\n",
+    "'''\n",
+    "Resolves current workspace ID from workspace description.\n",
+    "'''\n",
+    "def get_current_workspace_id():\n",
+    "    WORKSPACE_CMD_OUTPUT = !terra workspace describe --format=json | jq --raw-output \".id\"\n",
+    "    WORKSPACE_ID = WORKSPACE_CMD_OUTPUT[0]\n",
+    "    return WORKSPACE_ID\n",
+    "\n",
+    "CURRENT_WORKSPACE_ID = get_current_workspace_id()\n",
+    "print(f'Workspace ID: {CURRENT_WORKSPACE_ID}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "642ed933-7ff9-455e-ab8c-795ed34c6d6c",
+   "metadata": {},
+   "source": [
+    "## Connect to the BQ database"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e04796e5-b48a-46f5-a952-d9d0fefde5b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "BQ_dataset = 'bigquery-public-data.cms_synthetic_patient_data_omop'\n",
+    "\n",
+    "job_query_config = bigquery.QueryJobConfig(default_dataset=BQ_dataset)\n",
+    "client = bigquery.Client(default_query_job_config=job_query_config)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c59ab9e0-9cb4-4dc3-9118-cd12aaf42518",
+   "metadata": {},
+   "source": [
+    "## Example for medications containing Quinapril"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55c223d1-6706-42c6-b1ab-a8d31329597e",
+   "metadata": {},
+   "source": [
+    "The purpose of this example is to calculate the number of participants who were treated with drugs containing\n",
+    "the Quinapril molecule, a Beta Blocker.\n",
+    "As a starting point for this study, we need to find the RxCUI code of the Quinapril molecule with the [RxNav tool](https://mor.nlm.nih.gov/RxNav/) (https://mor.nlm.nih.gov/RxNav/search?searchBy=String&searchTerm=quinapril):\n",
+    "- Quinapril RxCUI: `35208`\n",
+    "\n",
+    "For this purpose, it is necessary to perform the following steps:\n",
+    "1. **Converting the RxCUI code of Quinapril molecule to concept ID**:\n",
+    "This step consists of finding the concept ID associated with the `35208` RxCUI code. To do this, we will use the `concept` table of the OMOP vocabulary and the `concept_code` equal to the RxCUI code for the `vocabulary_id` equal to \"RxNorm\". See the CTE `quinapril_RxNorm_concept_id` in the SQL query below.\n",
+    "\n",
+    "2. **Find the drug standard concept IDs**:\n",
+    "Drugs are coded with a standard concept ID (corresponding to a RxNorm code). Therefore, We need to find the concept IDs linked to drugs containing the Quinapril molecule. The CTE `medications_with_quinapril` in the SQL query below consists of extracting all the descendants of the ingredient concept ID from step 1, which are all the drugs containing the Metropol ingredient.\n",
+    "\n",
+    "3. **Find all drug concept IDs**:\n",
+    "Because some of the drugs may be coded using non-standard concept IDs, we recommend mapping the standard concept IDs identified in step 2 to obtain a comprehensive set of relevant concept IDs. This mapping is performed using the concept_relationship table of the OMOP vocabulary, where concept_id_2 is the standard concept ID(s) identified in step 1, and the relationship_id is 'Maps to'. See the CTE `all_medications_with_quinapril` in the SQL query below.\n",
+    "\n",
+    "4. **Calculate the number of participants who were treated with Quinapril**:\n",
+    "The next step is to extract and count the participants with at least one Quinapril drug exposure. We will use the `drug_exposure` table and filter only the drugs coded with a `drug_concept_id` corresponding to a concept ID of the previously extracted list. See the CTE `nb_of_participants_treated_with_quinapril` in the SQL query below.\n",
+    "\n",
+    "5. **Calculate the percentage of participants who were treated with Quinapril**:\n",
+    "Finally, the last step is to calculate the percentage who were treated with Quinapril out of the total number of participants. We will use the number of participants in the `person` table and calculate the percentage. See the CTE `nb_total_of_participants` in the SQL query below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "49fc6862-6ce9-4b29-a214-127747923aef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query = \"\"\"\n",
+    "    WITH quinapril_RxNorm_concept_id AS (\n",
+    "        SELECT \n",
+    "            concept_id\n",
+    "        FROM\n",
+    "            `concept`\n",
+    "        WHERE\n",
+    "            concept_code = \"35208\"\n",
+    "            AND vocabulary_id = \"RxNorm\"\n",
+    "    ),\n",
+    "    medications_with_quinapril AS (\n",
+    "        SELECT\n",
+    "            ancestor.descendant_concept_id AS concept_id\n",
+    "        FROM\n",
+    "            `concept_ancestor` AS ancestor\n",
+    "        INNER JOIN\n",
+    "            quinapril_RxNorm_concept_id AS quinapril\n",
+    "        ON\n",
+    "            ancestor.ancestor_concept_id = quinapril.concept_id\n",
+    "        INNER JOIN\n",
+    "            `concept` AS concept\n",
+    "        ON\n",
+    "            ancestor.descendant_concept_id = concept.concept_id\n",
+    "        WHERE\n",
+    "            concept.standard_concept = 'S'\n",
+    "    ),\n",
+    "    all_medications_with_quinapril AS (\n",
+    "        SELECT\n",
+    "            DISTINCT concept_id\n",
+    "        FROM (\n",
+    "            SELECT\n",
+    "                *\n",
+    "            FROM\n",
+    "                medications_with_quinapril\n",
+    "        ) UNION ALL (\n",
+    "            SELECT\n",
+    "                concept_id_1 AS concept_id\n",
+    "            FROM\n",
+    "                `concept_relationship`\n",
+    "            WHERE\n",
+    "                relationship_id = 'Maps to' \n",
+    "                AND concept_id_2 IN (\n",
+    "                    SELECT\n",
+    "                        concept_id\n",
+    "                    FROM\n",
+    "                        medications_with_quinapril\n",
+    "                )\n",
+    "        )\n",
+    "    ),\n",
+    "    nb_of_participants_treated_with_quinapril AS (\n",
+    "        SELECT\n",
+    "            COUNT(DISTINCT person_id) AS nb_of_participants_with_quinapril\n",
+    "        FROM\n",
+    "            `drug_exposure`\n",
+    "        INNER JOIN \n",
+    "            all_medications_with_quinapril\n",
+    "        ON\n",
+    "            drug_concept_id = concept_id\n",
+    "    ),\n",
+    "    nb_total_of_participants AS (\n",
+    "        SELECT\n",
+    "            COUNT(DISTINCT person_id) AS nb_of_participants\n",
+    "        FROM\n",
+    "            `person`\n",
+    "    )\n",
+    "    SELECT\n",
+    "        100*nb_of_participants_with_quinapril/nb_of_participants AS with_quinapril,\n",
+    "        100-(100*nb_of_participants_with_quinapril/nb_of_participants) AS without_quinapril,\n",
+    "    FROM\n",
+    "        nb_total_of_participants,\n",
+    "        nb_of_participants_treated_with_quinapril\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af2c22ac-5448-4465-b0e5-6a2d90b9df2b",
+   "metadata": {},
+   "source": [
+    "# Execute query\n",
+    "The below code will send a request to BigQuery to execute the query. The results will be stored in a Pandas dataframe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "09c4b5e6-0629-41ee-8433-26f203ea8941",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = client.query(query).result().to_dataframe()\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "977f7a1a-4335-43f0-b61b-e19d9342b12e",
+   "metadata": {},
+   "source": [
+    "# Plot visualization\n",
+    "The below code uses matplotlib to plot a simple histogram of the results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8581cafd-df77-4c6f-a0da-de32ca4d836a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ax = df.transpose().plot.pie(y=0, autopct='%.2f%%', title='Percentage of participants who were treated with Quinapril', ylabel='', legend=False)\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "environment": {
+   "kernel": "python3",
+   "name": "pytorch-gpu.1-13.m108",
+   "type": "gcloud",
+   "uri": "gcr.io/deeplearning-platform-release/pytorch-gpu.1-13:m108"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/omop_examples/extract_drug_treatments_from_a_molecule.ipynb
+++ b/omop_examples/extract_drug_treatments_from_a_molecule.ipynb
@@ -70,12 +70,25 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "6805ba9d-82a9-4598-8279-2a5d60667d48",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The following line resolves the workspace resource named cms_synthetic_patient_data_omop. \n",
+    "BQ_dataset = get_bq_dataset_from_reference('cms_synthetic_patient_data_omop')\n",
+    "# The above line will fail if you don't have this resource in your workspace.\n",
+    "\n",
+    "# If that is the case, you can hard code the BQ_dataset instead by uncommenting the following line. \n",
+    "# BQ_dataset = 'bigquery-public-data.cms_synthetic_patient_data_omop'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "e04796e5-b48a-46f5-a952-d9d0fefde5b3",
    "metadata": {},
    "outputs": [],
    "source": [
-    "BQ_dataset = get_bq_dataset_from_reference('cms_synthetic_patient_data_omop')\n",
-    "\n",
     "job_query_config = bigquery.QueryJobConfig(default_dataset=BQ_dataset)\n",
     "client = bigquery.Client(default_query_job_config=job_query_config)"
    ]

--- a/omop_examples/extract_medical_conditions_from_ICD_codes.ipynb
+++ b/omop_examples/extract_medical_conditions_from_ICD_codes.ipynb
@@ -49,12 +49,12 @@
    "outputs": [],
    "source": [
     "'''\n",
-    "Resolves bucket URL from bucket reference in workspace.\n",
+    "Resolves BQ dataset from reference in workspace.\n",
     "'''\n",
-    "def get_bucket_url_from_reference(bucket_reference):\n",
-    "    BUCKET_CMD_OUTPUT = !terra resolve --name={bucket_reference}\n",
-    "    BUCKET = BUCKET_CMD_OUTPUT[0]\n",
-    "    return BUCKET\n",
+    "def get_bq_dataset_from_reference(resource_name):\n",
+    "    BQ_CMD_OUTPUT = !terra resolve --name={resource_name}\n",
+    "    BQ_DATASET = BQ_CMD_OUTPUT[0]\n",
+    "    return BQ_DATASET\n",
     "\n",
     "'''\n",
     "Resolves current workspace ID from workspace description.\n",
@@ -83,7 +83,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "BQ_dataset = 'bigquery-public-data.cms_synthetic_patient_data_omop'\n",
+    "BQ_dataset = get_bq_dataset_from_reference('cms_synthetic_patient_data_omop')\n",
     "\n",
     "job_query_config = bigquery.QueryJobConfig(default_dataset=BQ_dataset)\n",
     "client = bigquery.Client(default_query_job_config=job_query_config)"

--- a/omop_examples/extract_medical_conditions_from_ICD_codes.ipynb
+++ b/omop_examples/extract_medical_conditions_from_ICD_codes.ipynb
@@ -1,0 +1,320 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d4753f46-ea81-471e-9cfb-fdab151e6267",
+   "metadata": {},
+   "source": [
+    "# CMS SynPuf: How to extract medical conditions based on ICD-10 codes\n",
+    "\n",
+    "This notebook queries the [CMS SynPuf dataset](https://console.cloud.google.com/marketplace/product/hhs/synpuf?pli=1), a public synthetic patient data in OMOP. This notebook is intended to be used as an example for how to query the public OMOP dataset, and how to do basic visualizations."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7f8336bd-793c-4cba-9217-0927e1b16f87",
+   "metadata": {},
+   "source": [
+    "## Import python libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "71671891-b357-4b3d-9af1-1b5a67a1f340",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from google.cloud import bigquery\n",
+    "\n",
+    "# Enable IPython to display matplotlib graphs.\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "829bf5be-f4f6-4c53-8273-c9713e197eaa",
+   "metadata": {},
+   "source": [
+    "## Notebook setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "58ed7536-2975-46aa-96d5-c9c61bde0a0e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "'''\n",
+    "Resolves bucket URL from bucket reference in workspace.\n",
+    "'''\n",
+    "def get_bucket_url_from_reference(bucket_reference):\n",
+    "    BUCKET_CMD_OUTPUT = !terra resolve --name={bucket_reference}\n",
+    "    BUCKET = BUCKET_CMD_OUTPUT[0]\n",
+    "    return BUCKET\n",
+    "\n",
+    "'''\n",
+    "Resolves current workspace ID from workspace description.\n",
+    "'''\n",
+    "def get_current_workspace_id():\n",
+    "    WORKSPACE_CMD_OUTPUT = !terra workspace describe --format=json | jq --raw-output \".id\"\n",
+    "    WORKSPACE_ID = WORKSPACE_CMD_OUTPUT[0]\n",
+    "    return WORKSPACE_ID\n",
+    "\n",
+    "CURRENT_WORKSPACE_ID = get_current_workspace_id()\n",
+    "print(f'Workspace ID: {CURRENT_WORKSPACE_ID}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "642ed933-7ff9-455e-ab8c-795ed34c6d6c",
+   "metadata": {},
+   "source": [
+    "## Connect to the BQ database"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e04796e5-b48a-46f5-a952-d9d0fefde5b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "BQ_dataset = 'bigquery-public-data.cms_synthetic_patient_data_omop'\n",
+    "\n",
+    "job_query_config = bigquery.QueryJobConfig(default_dataset=BQ_dataset)\n",
+    "client = bigquery.Client(default_query_job_config=job_query_config)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c59ab9e0-9cb4-4dc3-9118-cd12aaf42518",
+   "metadata": {},
+   "source": [
+    "## Example for history of skin conditions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55c223d1-6706-42c6-b1ab-a8d31329597e",
+   "metadata": {},
+   "source": [
+    "The purpose of this example is to calculate the number of participants with a diagnosis of skin condition based on a list of ICD-10 codes.\n",
+    "As a starting point for this study, we define the diagnosis of skin condition as a condition coded with an ICD-10 code from the following list:\n",
+    "- `L70.*`: Acne\n",
+    "- `L20.*`: Atopic dermatitis\n",
+    "- `L40.*`: Psoriasis\n",
+    "- `L80.*`: Vitiligo\n",
+    "\n",
+    "where \"\\*\" corresponds to any sequence of numbers.\n",
+    "\n",
+    "For this purpose, it is necessary to perform the following steps:\n",
+    "1. **Converting the ICD-10 codes of skin condition to concept IDs**:\n",
+    "This step consists of finding the concept IDs associated with the ICD-10 codes in the following list: `L70`, `L20`, `L40` and `L80`. To do this, we will use the `concept` table of the OMOP vocabulary and find all `concept_code` equal to one of the ICD-10 codes for the `vocabulary_id` equal to \"ICD10CM\". See the CTE `skin_condition_ICD_concept_ids` in the SQL query below.\n",
+    "\n",
+    "2. **Find the standard concept IDs linked to the ICD-10 concept IDs**:\n",
+    "The majority of conditions are coded with a standard concept ID (corresponding to a SNOMED code). Therefore, we need to find the standard concept IDs corresponding to the concept IDs previously extracted in step 1. The CTE `standard_concept_ids` in the SQL query below consists of retrieving only the standard concept IDs from the `concept` table (i.e., `standard_concept` equal to \"S\") and the CTE `skin_condition_standard_concept_ids` consists of mapping the concept IDs from step 1 to the standard concept IDs (i.e., using the `concept_relationship` table with `relationship_id` equal to \"Maps to\").\n",
+    "\n",
+    "3. **Find all concept IDs linked to the standard skin condition concept IDs**:\n",
+    "The dataset may also contain non-standard concept IDs. To ensure that we include patients who have a diagnosis of skin condition using a non-standard concept ID, we need to find all concept IDs associated with the core set of standard concept IDs identified in the previous step. To do this, we again use the `concept_relationship` table, setting our standard concept IDs as concept_id_2 when using the `relationship_id` of \"Maps to\". We union these with our standard concept IDs to get a full set of skin condition concept_ids. See the CTEs `skin_condition_nonstandard_concept_ids` and `skin_condition_all_concept_ids` in the SQL query below.\n",
+    "\n",
+    "4. **Find all the descendants of the skin condition concept IDs**:\n",
+    "The condition concept IDs are organized under an ontology with different levels of precision. Therefore, to capture all concept IDs for skin condition, we must also find all descendants of the concept IDs previously extracted in step 3. To do this, we will use the `concept_ancestor` table with the `ancestor_concept_id` equal to the concept IDs from step 3 and extract all `descendant_concept_id` as the final list `all_concept_ids_with_descendants` in the SQL query below.\n",
+    "\n",
+    "5. **Calculate the number of participants with a diagnosis of skin condition**:\n",
+    "Finally, the last step is to extract and count the participants with at least one diagnosis of skin condition. We will use the `condition_occurrence` table and filter only the conditions coded with a `condition_concept_id` corresponding to a concept ID of the previously extracted list. See the CTE `nb_of_participants_diagnosed_with_skin_condition` in the SQL query below.\n",
+    "\n",
+    "6. **Calculate the percentage of participants with a diagnosis of skin condition**:\n",
+    "Finally, the last step is to calculate the percentage with at least one diagnosis of skin condition out of the total number of participants. We will use the number of participants in the `person` table and calculate the percentage. See the CTE `nb_total_of_participants` in the SQL query below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "49fc6862-6ce9-4b29-a214-127747923aef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query = \"\"\"\n",
+    "    WITH skin_condition_ICD_concept_ids AS (\n",
+    "        SELECT \n",
+    "            concept_id,\n",
+    "            CASE concept_code\n",
+    "                WHEN 'L70' THEN 'Acne'\n",
+    "                WHEN 'L20' THEN 'Atopic dermatitis'\n",
+    "                WHEN 'L40' THEN 'Psoriasis'\n",
+    "                ELSE 'Vitiligo'\n",
+    "            END AS skin_condition\n",
+    "        FROM\n",
+    "            `concept`\n",
+    "        WHERE\n",
+    "            concept_code IN ('L70', 'L20', 'L40', 'L80')\n",
+    "            AND vocabulary_id = 'ICD10CM'\n",
+    "    ),\n",
+    "    standard_concept_ids AS (\n",
+    "        SELECT \n",
+    "            concept_id\n",
+    "        FROM\n",
+    "            `concept`\n",
+    "        WHERE\n",
+    "            standard_concept = 'S'\n",
+    "    ),\n",
+    "    skin_condition_standard_concept_ids AS (\n",
+    "        SELECT\n",
+    "            skin_condition,\n",
+    "            standard_concept_ids.concept_id\n",
+    "        FROM\n",
+    "            skin_condition_ICD_concept_ids\n",
+    "        INNER JOIN\n",
+    "            `concept_relationship`\n",
+    "        ON\n",
+    "            skin_condition_ICD_concept_ids.concept_id = concept_id_1\n",
+    "        INNER JOIN\n",
+    "            standard_concept_ids\n",
+    "        ON\n",
+    "            standard_concept_ids.concept_id = concept_id_2\n",
+    "        WHERE\n",
+    "            relationship_id = 'Maps to'\n",
+    "    ),\n",
+    "    skin_condition_nonstandard_concept_ids AS (\n",
+    "        SELECT\n",
+    "            skin_condition,\n",
+    "            concept_id_1 AS concept_id\n",
+    "        FROM\n",
+    "            `concept_relationship`\n",
+    "        INNE JOIN\n",
+    "            skin_condition_standard_concept_ids\n",
+    "        ON\n",
+    "            relationship_id = 'Maps to'\n",
+    "            AND concept_id_2 = concept_id\n",
+    "    ),\n",
+    "    skin_condition_all_concept_ids AS (\n",
+    "        SELECT DISTINCT\n",
+    "            skin_condition,\n",
+    "            concept_id\n",
+    "        FROM (\n",
+    "            SELECT\n",
+    "                *\n",
+    "            FROM\n",
+    "                skin_condition_standard_concept_ids\n",
+    "        ) UNION ALL (\n",
+    "            SELECT\n",
+    "                *\n",
+    "            FROM\n",
+    "                skin_condition_nonstandard_concept_ids\n",
+    "        )\n",
+    "    ),\n",
+    "    skin_condition_all_concept_ids_with_descendants AS (\n",
+    "        SELECT\n",
+    "            skin_condition,\n",
+    "            descendant_concept_id AS concept_id\n",
+    "        FROM\n",
+    "            skin_condition_all_concept_ids\n",
+    "        INNER JOIN\n",
+    "            `concept_ancestor`\n",
+    "        ON\n",
+    "            concept_id = ancestor_concept_id\n",
+    "    ),\n",
+    "    nb_of_participants_diagnosed_with_skin_condition AS (\n",
+    "        SELECT\n",
+    "            skin_condition,\n",
+    "            COUNT(DISTINCT person_id) AS nb_of_participants_with_skin_condition\n",
+    "        FROM\n",
+    "            `condition_occurrence`\n",
+    "        INNER JOIN\n",
+    "            skin_condition_all_concept_ids_with_descendants\n",
+    "        ON\n",
+    "            condition_concept_id = concept_id\n",
+    "        GROUP BY \n",
+    "            skin_condition\n",
+    "    ),\n",
+    "    nb_total_of_participants AS (\n",
+    "        SELECT\n",
+    "            COUNT(DISTINCT person_id) AS nb_of_participants\n",
+    "        FROM\n",
+    "            `person`\n",
+    "    )\n",
+    "    SELECT\n",
+    "        skin_condition,\n",
+    "        100*nb_of_participants_with_skin_condition/nb_of_participants AS percentage_of_participants,\n",
+    "    FROM\n",
+    "        nb_total_of_participants,\n",
+    "        nb_of_participants_diagnosed_with_skin_condition\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "43a3584f-f5cd-497b-8233-3b094156fe27",
+   "metadata": {},
+   "source": [
+    "# Execute query\n",
+    "The below code will send a request to BigQuery to execute the query. The results will be stored in a Pandas dataframe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d64848a6-9e11-45c1-a152-846a3b2d957a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = client.query(query).result().to_dataframe()\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ffec7072-9fe0-41ad-9919-e725ebce4438",
+   "metadata": {},
+   "source": [
+    "# Plot visualization\n",
+    "The below code uses matplotlib to plot a simple histogram of the results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f27b7b5a-6608-4c94-a87f-5c0ba2e2dc4b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ax = df.plot.bar(x='skin_condition', y='percentage_of_participants', title='Percentage of participants with a diagnosis of skin condition', rot=0, ylabel='', xlabel='', legend=False)\n",
+    "# Add bar labels\n",
+    "for p in ax.patches:\n",
+    "    ax.annotate('%.2f%%' % (p.get_height()), (p.get_x()+0.07, p.get_height()+0.03))\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "environment": {
+   "kernel": "python3",
+   "name": "pytorch-gpu.1-13.m108",
+   "type": "gcloud",
+   "uri": "gcr.io/deeplearning-platform-release/pytorch-gpu.1-13:m108"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/omop_examples/extract_medical_conditions_from_ICD_codes.ipynb
+++ b/omop_examples/extract_medical_conditions_from_ICD_codes.ipynb
@@ -54,18 +54,7 @@
     "def get_bq_dataset_from_reference(resource_name):\n",
     "    BQ_CMD_OUTPUT = !terra resolve --name={resource_name}\n",
     "    BQ_DATASET = BQ_CMD_OUTPUT[0]\n",
-    "    return BQ_DATASET\n",
-    "\n",
-    "'''\n",
-    "Resolves current workspace ID from workspace description.\n",
-    "'''\n",
-    "def get_current_workspace_id():\n",
-    "    WORKSPACE_CMD_OUTPUT = !terra workspace describe --format=json | jq --raw-output \".id\"\n",
-    "    WORKSPACE_ID = WORKSPACE_CMD_OUTPUT[0]\n",
-    "    return WORKSPACE_ID\n",
-    "\n",
-    "CURRENT_WORKSPACE_ID = get_current_workspace_id()\n",
-    "print(f'Workspace ID: {CURRENT_WORKSPACE_ID}')"
+    "    return BQ_DATASET"
    ]
   },
   {

--- a/omop_examples/extract_medical_conditions_from_ICD_codes.ipynb
+++ b/omop_examples/extract_medical_conditions_from_ICD_codes.ipynb
@@ -68,12 +68,25 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "1886c87f-4ff1-460a-82c5-2c24ba783b2f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The following line resolves the workspace resource named cms_synthetic_patient_data_omop. \n",
+    "BQ_dataset = get_bq_dataset_from_reference('cms_synthetic_patient_data_omop')\n",
+    "# The above line will fail if you don't have this resource in your workspace.\n",
+    "\n",
+    "# If that is the case, you can hard code the BQ_dataset instead by uncommenting the following line. \n",
+    "# BQ_dataset = 'bigquery-public-data.cms_synthetic_patient_data_omop'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "e04796e5-b48a-46f5-a952-d9d0fefde5b3",
    "metadata": {},
    "outputs": [],
    "source": [
-    "BQ_dataset = get_bq_dataset_from_reference('cms_synthetic_patient_data_omop')\n",
-    "\n",
     "job_query_config = bigquery.QueryJobConfig(default_dataset=BQ_dataset)\n",
     "client = bigquery.Client(default_query_job_config=job_query_config)"
    ]


### PR DESCRIPTION
These notebooks were originally designed by @jeancoquet from https://github.com/verily-src/terra-solutions-hhr-analysis-examples. They are adapted to query from the public CMS SynPuf dataset. 