### PR TITLE
Only normalize line endings to LF for text files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/dataproc/batch_job_submit.ipynb
+++ b/dataproc/batch_job_submit.ipynb
@@ -118,7 +118,6 @@
    "execution_count": null,
    "id": "517a6513-4768-4960-8215-035e124ac1c9",
    "metadata": {
-    "scrolled": true,
     "tags": []
    },
    "outputs": [],


### PR DESCRIPTION
Setting this value to auto directs Git to normalize line endings for only text files, leaving binary files in tact. This should prevent the phenomenon [seen here](https://screenshot.googleplex.com/a53oRqRRJVid7D3), where a file appears to have an untracked change, due to line endings, in spite of not being modified by the user.