### PR TITLE
Update data collection creation notebook

### DIFF
--- a/first_hour_on_vwb/README.md
+++ b/first_hour_on_vwb/README.md
@@ -7,9 +7,9 @@ New users who engage with this workspace will be exposed to a variety of helpful
 
 ## Getting started
 
-- Run the [working_with_bq_resources.ipynb](https://github.com/DataBiosphere/terra-axon-examples/blob/main/first_hour_on_vwb/working_with_bq_resources.ipynb) notebook to learn about various options for interacting with BigQuery data from [referenced resources](https://support.workbench.verily.com/docs/how_to_guides/work_with_data/#add-a-data-reference) in your workspace.
+- Run the [working_with_bq_resources.ipynb](https://github.com/DataBiosphere/terra-axon-examples/blob/main/first_hour_on_vwb/working_with_bq_resources.ipynb) notebook to learn about various options for interacting with BigQuery data from [referenced resources](https://support.workbench.verily.com/docs/technical_reference/data_resources/#referenced-vs-workspace-controlled-data-resources) in your workspace.
 
-- Run the [working_with_groups.ipynb](https://github.com/DataBiosphere/terra-axon-examples/blob/main/first_hour_on_vwb/working_with_groups.ipynb) notebook to learn about creating and deleting [Workbench groups](https://terra-docs.api.verily.com/docs/reference/glossary/#group) and managing Workbench group membership.
+- Run the [working_with_groups.ipynb](https://github.com/DataBiosphere/terra-axon-examples/blob/main/first_hour_on_vwb/working_with_groups.ipynb) notebook to learn about creating and deleting [Workbench groups](https://support.workbench.verily.com/docs/technical_reference/admin/user_groups/) and managing Workbench group membership.
 
 - Run the [working_with_resources.ipynb](https://github.com/DataBiosphere/terra-axon-examples/blob/main/first_hour_on_vwb/working_with_resources.ipynb) notebook to learn about creating, accessing, adding, and removing referenced and controlled resources in your workspace.
 

--- a/first_hour_on_vwb/creating_a_data_collection.ipynb
+++ b/first_hour_on_vwb/creating_a_data_collection.ipynb
@@ -89,7 +89,7 @@
     "Resolves ID of current workspace.\n",
     "'''\n",
     "def get_current_workspace_id():\n",
-    "    CURRENT_WORKSPACE_ID_CMD_OUTPUT = !terra workspace describe --format=json | jq --raw-output \".id\"\n",
+    "    CURRENT_WORKSPACE_ID_CMD_OUTPUT = !wb workspace describe --format=json | jq --raw-output \".id\"\n",
     "    CURRENT_WORKSPACE_ID = CURRENT_WORKSPACE_ID_CMD_OUTPUT[0]\n",
     "    return CURRENT_WORKSPACE_ID\n",
     "\n",
@@ -118,7 +118,7 @@
     "### Restricting discovery access to a data collection\n",
     "\n",
     "<div class=\"alert alert-block alert-success\">\n",
-    "<b>Note:</b> Unless a group membership <a href=\"https://terra-docs.api.verily.com/docs/https://terra-docs.api.verily.com/docs/reference/glossary/#policy\">policy</a> is applied <b>at the creation time for the data collection's underlying workspace</b>, your data collection will be discoverable to all Workbench users.</div> \n",
+    "<b>Note:</b> Unless a group membership <a href=\"https://support.workbench.verily.com/docs/technical_reference/workspaces/access_control_and_sharing/#limiting-workspace-access-with-a-group-policy\">policy</a> is applied <b>at the creation time for the data collection's underlying workspace</b>, your data collection will be discoverable to all Workbench users.</div> \n",
     "<p>If a user has discovery access to a data collection, they are able to see its name and short description in the <a href=\"https://support.workbench.verily.com/docs/technical_reference/data_resources/#data-catalog-and-collections\">data catalog</a>. In order to have read access to the resources in a data collection, users and/or groups must still be explicitly granted access to the data collection-backing workspace via the Workbench UI or CLI by the data collection owner.</p>\n",
     "<h4>Adding a group membership policy</h4>\n",
     "<p>When a <a href=\"https://support.workbench.verily.com/docs/how_to_guides/creating_data_collections/#group-policies\">group membership policy</a> is added to a data collection-backing workspace at creation time, only members of that group will see the data collection in the data catalog. </p>\n",
@@ -200,7 +200,7 @@
     "    def create_workspace(self,b):\n",
     "        with self.output:\n",
     "            createWorkspaceCommandList = [\n",
-    "                \"terra\", \"workspace\", \"create\",\n",
+    "                \"wb\", \"workspace\", \"create\",\n",
     "                f\"--id={self.input_workspace_id.value.strip()}\",\n",
     "                f\"--description={self.input_description.value.strip()}\",\n",
     "                f\"--name={self.input_name.value.strip()}\",\n",
@@ -281,7 +281,7 @@
     "        return self.input_workspace_id.value.strip()\n",
     "\n",
     "    def get_workspace_ids(self):\n",
-    "        result = subprocess.run([\"terra\",\"workspace\",\"list\",\"--format=JSON\"],capture_output=True,text=True)\n",
+    "        result = subprocess.run([\"wb\",\"workspace\",\"list\",\"--format=JSON\"],capture_output=True,text=True)\n",
     "        ids_list = wu.list_workspace_ids(result.stdout)\n",
     "        # Insert empty string to display as value of dropdown until changed by user.\n",
     "        ids_list.insert(0, \" \")\n",
@@ -291,14 +291,14 @@
     "        workspace_id = self.input_workspace_id.value\n",
     "        short_desc = self.input_short_description.value\n",
     "        with self.output:\n",
-    "            prettyConvertToDataCollectionCommand = f\"\"\"terra workspace set-property \\\\\n",
+    "            prettyConvertToDataCollectionCommand = f\"\"\"wb workspace set-property \\\\\n",
     "            --workspace={workspace_id} \\\\\n",
     "            --properties=\\\"terra-type=data-collection,terra-workspace-short-description={short_desc}\\\"\n",
     "            \"\"\"\n",
     "            print(\"Running command to convert workspace to data collection...\")\n",
     "            print(prettyConvertToDataCollectionCommand)\n",
     "            print(\"Your data collection will be ready in less than one minute...\")\n",
-    "            result = subprocess.run([\"terra\",\"workspace\",\"set-property\",\n",
+    "            result = subprocess.run([\"wb\",\"workspace\",\"set-property\",\n",
     "                                     f\"--workspace={workspace_id}\",\n",
     "                                     f\"--properties=terra-type=data-collection,terra-workspace-short-description={short_desc}\"],\n",
     "                                    capture_output=True,text=True)\n",
@@ -387,7 +387,7 @@
     "        ], layout=wu.vbox_layout)\n",
     "\n",
     "    def get_data_collections(self):\n",
-    "        result = subprocess.run([\"terra\",\"workspace\",\"list\",\"--format=JSON\"],capture_output=True,text=True)\n",
+    "        result = subprocess.run([\"wb\",\"workspace\",\"list\",\"--format=JSON\"],capture_output=True,text=True)\n",
     "        ids_list = wu.list_data_collections(result.stdout)\n",
     "        # Insert empty string to display as value of dropdown until changed by user.\n",
     "        ids_list.insert(0,'')\n",
@@ -404,20 +404,20 @@
     "            description = self.input_description.value.strip()\n",
     "            \n",
     "            # 1) Point cloud env to target data-collection workspace.\n",
-    "            setWorkspaceCommand = f\"terra workspace set --id={workspace_id}\"\n",
+    "            setWorkspaceCommand = f\"wb workspace set --id={workspace_id}\"\n",
     "            setWorkspaceResult = subprocess.run(setWorkspaceCommand, shell = True, capture_output = True, text = True)\n",
     "            print(setWorkspaceResult.stderr) if not setWorkspaceResult.stdout else print(setWorkspaceResult.stdout)\n",
     "\n",
     "            # 2) Create version folder.            \n",
     "            if description is not None:\n",
-    "                createVersionCommand = f\"terra folder create --name={version} --description=\\\"{description}\\\" --workspace={workspace_id}\"\n",
+    "                createVersionCommand = f\"wb folder create --name={version} --description=\\\"{description}\\\" --workspace={workspace_id}\"\n",
     "            else:\n",
-    "                createVersionCommand = f\"terra folder create --name={version} --workspace={workspace_id}\"\n",
+    "                createVersionCommand = f\"wb folder create --name={version} --workspace={workspace_id}\"\n",
     "            createVersionResult = subprocess.run(createVersionCommand, capture_output = True, text = True, shell = True)\n",
     "            print(createVersionResult.stderr) if not createVersionResult.stdout else print(createVersionResult.stdout)\n",
     "            \n",
-    "            # 3) Get file tree from Terra CLI.\n",
-    "            folderTreeResult = subprocess.run([\"terra\", \"folder\", \"tree\", \"--format=JSON\"], capture_output = True, text = True)\n",
+    "            # 3) Get file tree from Workbench CLI.\n",
+    "            folderTreeResult = subprocess.run([\"wb\", \"folder\", \"tree\", \"--format=JSON\"], capture_output = True, text = True)\n",
     "\n",
     "            # 4) Search tree for ID of desired version folder.\n",
     "            folder_id = vfu.get_folder_id(version,json.loads(folderTreeResult.stdout))\n",
@@ -425,7 +425,7 @@
     "            # 6) Publish desired folder as a version with today's date.\n",
     "            today = date.today()\n",
     "            formatted_date = today.strftime(\"%Y-%m-%d\")\n",
-    "            publishVersionCommand = f\"terra folder set-property --properties=terra-published-date={formatted_date} --id={folder_id}\"\n",
+    "            publishVersionCommand = f\"wb folder set-property --properties=terra-published-date={formatted_date} --id={folder_id}\"\n",
     "            publishVersionResult = subprocess.run(publishVersionCommand, shell = True, capture_output = True, text = True, check = True)\n",
     "            print(publishVersionResult.stderr) if not publishVersionResult.stdout else print(publishVersionResult.stdout)\n",
     "\n",
@@ -447,9 +447,9 @@
     "* Run the following Workbench CLI commands to get the version folder's ID, then move a resource to the version folder:\n",
     "\n",
     "        # Get ID for version folder\n",
-    "        terra folder tree\n",
+    "        wb folder tree\n",
     "        # Move desired resource to version folder\n",
-    "        terra resource move --folder-id=<FOLDER_ID> --name=<RESOURCE_NAME> --workspace=<WORKSPACE_ID>\n",
+    "        wb resource move --folder-id=<FOLDER_ID> --name=<RESOURCE_NAME> --workspace=<WORKSPACE_ID>\n",
     "* Use the widgets provided in [../workspace_resource_examples.ipynb](../workspace_resource_examples.ipynb../workspace_resource_examples.ipynb) to create controlled and add referenced resources to the data collection's backing workspace, then move them to the version folder."
    ]
   },
@@ -525,7 +525,7 @@
     "        self.button.on_click(self.add_release_notes)\n",
     "\n",
     "    def get_data_collections(self):\n",
-    "        result = subprocess.run([\"terra\",\"workspace\",\"list\",\"--format=JSON\"],capture_output=True,text=True)\n",
+    "        result = subprocess.run([\"wb\",\"workspace\",\"list\",\"--format=JSON\"],capture_output=True,text=True)\n",
     "        ids_list = wu.list_data_collections(result.stdout)\n",
     "        # Insert empty string to display as value of dropdown until changed by user.\n",
     "        ids_list.insert(0,'')\n",
@@ -539,18 +539,18 @@
     "            notes_url = self.input_notes_url.value.strip()\n",
     "            \n",
     "            # 1) Point cloud env to target data-collection workspace.\n",
-    "            setWorkspaceCommand = f\"terra workspace set --id={workspace_id}\"\n",
+    "            setWorkspaceCommand = f\"wb workspace set --id={workspace_id}\"\n",
     "            setWorkspaceResult = subprocess.run(setWorkspaceCommand, shell = True, capture_output = True, text = True)\n",
     "            print(setWorkspaceResult.stderr) if not setWorkspaceResult.stdout else print(setWorkspaceResult.stdout)\n",
     "\n",
-    "            # 2) Get file tree from Terra CLI.\n",
-    "            folderTreeResult = subprocess.run([\"terra\", \"folder\", \"tree\", \"--format=JSON\"], capture_output = True, text = True)\n",
+    "            # 2) Get file tree from Workbench CLI.\n",
+    "            folderTreeResult = subprocess.run([\"wb\", \"folder\", \"tree\", \"--format=JSON\"], capture_output = True, text = True)\n",
     "\n",
     "            # 3) Search tree for ID of desired version folder.\n",
     "            folder_id = vfu.get_folder_id(version,json.loads(folderTreeResult.stdout))\n",
     "\n",
     "            # 4) Run command to add release notes URL to version.\n",
-    "            attachNotesCommand = [\"terra\", \"folder\", \"set-property\", f\"--properties=terra-release-notes-url={notes_url}\", f\"--id={folder_id}\", f\"--workspace={workspace_id}\"]\n",
+    "            attachNotesCommand = [\"wb\", \"folder\", \"set-property\", f\"--properties=terra-release-notes-url={notes_url}\", f\"--id={folder_id}\", f\"--workspace={workspace_id}\"]\n",
     "            attachNotesResult = subprocess.run(attachNotesCommand, capture_output = True, text = True, check = True)\n",
     "            print(attachNotesResult.stderr) if not attachNotesResult.stdout else print(attachNotesResult.stdout)\n",
     "            \n",
@@ -569,7 +569,7 @@
     "\n",
     "Follow the steps below to add your new data collection to a Workbench workspace.<br>The video below provides a visual walkthrough of these steps.\n",
     "\n",
-    "1. In the [Workbench workspace UI](https://terra.verily.com/workspaces), select a workspace that is NOT the data collection workspace.\n",
+    "1. In the [Workbench workspace UI](https://workbench.verily.com/workspaces), select a workspace that is NOT the data collection workspace.\n",
     "1. Navigate to the Resources tab.\n",
     "1. Click the \"+ Data catalog\" button.\n",
     "1. Select your newly created data collection from those listed in the modal.\n",
@@ -592,7 +592,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "!date"
@@ -608,7 +610,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "!conda env export"
@@ -624,7 +628,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "!jupyter labextension list"
@@ -640,7 +646,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "!grep ^processor /proc/cpuinfo | wc -l"
@@ -656,7 +664,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "!grep \"^MemTotal:\" /proc/meminfo"
@@ -667,23 +677,30 @@
    "metadata": {},
    "source": [
     "---\n",
-    "Copyright 2023 Verily Life Sciences LLC\n",
+    "Copyright 2024 Verily Life Sciences LLC\n",
     "\n",
     "Use of this source code is governed by a BSD-style   \n",
     "license that can be found in the LICENSE file or at   \n",
     "https://developers.google.com/open-source/licenses/bsd"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "environment": {
    "kernel": "python3",
-   "name": "r-cpu.4-2.m110",
+   "name": ".m115",
    "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/r-cpu.4-2:m110"
+   "uri": "gcr.io/deeplearning-platform-release/:m115"
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3 (Local)",
    "language": "python",
    "name": "python3"
   },
@@ -697,7 +714,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.12"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/first_hour_on_vwb/widget_utils.py
+++ b/first_hour_on_vwb/widget_utils.py
@@ -26,7 +26,7 @@ vbox_layout = widgets.Layout(
 )
 
 def list_bq_tables(json_string):
-    """ Return a list of all BigQuery tables accessible from this workspace, given output of `terra resource list`.
+    """ Return a list of all BigQuery tables accessible from this workspace, given output of `wb resource list`.
     """
     all_tables = []
     json_data = json.loads(json_string)
@@ -77,7 +77,7 @@ def list_group_members(json_string):
 
 def list_data_collections(json_string):
     """
-    Given the output of the command `terra workspace list`, 
+    Given the output of the command `wb workspace list`, 
     returns a list of data collections.
     """
     json_data = json.loads(json_string)
@@ -85,13 +85,13 @@ def list_data_collections(json_string):
     for row in json_data:
         ws_id = row['id']
         ws_properties = row['properties']
-        if ws_properties.get('terra-type') == 'data-collection':
+        if ws_properties.get('wb-type') == 'data-collection':
             id_list.append(ws_id)
     return id_list
 
 def list_workspace_ids(json_string):
     """
-    Given the output of the command `terra workspace list`, 
+    Given the output of the command `wb workspace list`, 
     returns a list of workspace IDs that are not data collections.
     """
     json_data = json.loads(json_string)


### PR DESCRIPTION
Update the data collection creation notebook to replace `terra` with `wb` to reflect recent CLI migration. See [screencast](https://screencast.googleplex.com/cast/NTc0NTYzNjI5MTkwMzQ4OHxkMzU1MDczNC0xYw) of fully-executed notebook with updates; all widgets, outputs as expected. Also update copyright to reflect current year (2024).